### PR TITLE
chore(auth): add doc information to endpoints: dtos and examples

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,10 +8,23 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import type { FastifyReply } from 'fastify';
 import { AuthService, AuthTokensResponse } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { AuthResponseDto } from './dto/auth-response.dto';
+import { AuthenticatedUserDto } from './dto/authenticated-user.dto';
+import { LogoutResponseDto } from './dto/logout-response.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RefreshJwtGuard } from './guards/refresh-auth.guard';
 import { GetUserContext } from './decorators/get-user-context.decorator';
@@ -20,6 +33,7 @@ import { ConfigService } from '../infrastructure/config';
 
 type AuthHttpResponse = Omit<AuthTokensResponse, 'refreshToken'>;
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(
@@ -27,6 +41,19 @@ export class AuthController {
     private readonly configService: ConfigService,
   ) {}
 
+  @ApiOperation({
+    summary: 'Register a new user',
+    description:
+      'Creates a new account, returns an access token, and writes the refresh token into an HttpOnly cookie.',
+  })
+  @ApiCreatedResponse({
+    description:
+      'User was created successfully. The refresh token is returned via the `refreshToken` cookie.',
+    type: AuthResponseDto,
+  })
+  @ApiConflictResponse({
+    description: 'A user with this email already exists.',
+  })
   @Post('register')
   async register(
     @Body() dto: RegisterDto,
@@ -38,6 +65,19 @@ export class AuthController {
     return this.toHttpAuthResponse(authResult);
   }
 
+  @ApiOperation({
+    summary: 'Log in',
+    description:
+      'Authenticates the user, returns an access token, and writes the refresh token into an HttpOnly cookie.',
+  })
+  @ApiOkResponse({
+    description:
+      'Authentication succeeded. The refresh token is returned via the `refreshToken` cookie.',
+    type: AuthResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Credentials are invalid or the account cannot authenticate.',
+  })
   @HttpCode(HttpStatus.OK)
   @Post('login')
   async login(
@@ -50,6 +90,19 @@ export class AuthController {
     return this.toHttpAuthResponse(authResult);
   }
 
+  @ApiOperation({
+    summary: 'Get current user',
+    description:
+      'Returns the current authenticated user using the Bearer access token.',
+  })
+  @ApiBearerAuth('access-token')
+  @ApiOkResponse({
+    description: 'Current authenticated user.',
+    type: AuthenticatedUserDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Bearer token is missing or invalid.',
+  })
   @UseGuards(JwtAuthGuard)
   @Get('me')
   me(
@@ -58,6 +111,20 @@ export class AuthController {
     return authUser;
   }
 
+  @ApiOperation({
+    summary: 'Refresh access token',
+    description:
+      'Uses the HttpOnly `refreshToken` cookie to rotate the refresh token and issue a new access token.',
+  })
+  @ApiCookieAuth('refresh-token')
+  @ApiOkResponse({
+    description:
+      'Tokens were refreshed successfully. A new refresh token is returned via the `refreshToken` cookie.',
+    type: AuthResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Refresh cookie is missing, expired, revoked, or invalid.',
+  })
   @UseGuards(RefreshJwtGuard)
   @HttpCode(HttpStatus.OK)
   @Post('refresh')
@@ -71,6 +138,19 @@ export class AuthController {
     return this.toHttpAuthResponse(authResult);
   }
 
+  @ApiOperation({
+    summary: 'Log out',
+    description:
+      'Revokes the current refresh token and clears the `refreshToken` cookie.',
+  })
+  @ApiCookieAuth('refresh-token')
+  @ApiOkResponse({
+    description: 'Logout completed and the refresh cookie was cleared.',
+    type: LogoutResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Refresh cookie is missing or invalid.',
+  })
   @UseGuards(RefreshJwtGuard)
   @HttpCode(HttpStatus.OK)
   @Post('logout')

--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AuthenticatedUserDto } from './authenticated-user.dto';
+
+export class AuthResponseDto {
+  @ApiProperty({
+    description: 'Short-lived JWT access token to be sent as Bearer token.',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  accessToken!: string;
+
+  @ApiProperty({
+    description: 'Authenticated user payload.',
+    type: AuthenticatedUserDto,
+  })
+  user!: AuthenticatedUserDto;
+}

--- a/src/auth/dto/authenticated-user.dto.ts
+++ b/src/auth/dto/authenticated-user.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole, UserStatus } from '../../../generated/prisma/enums';
+
+export class AuthenticatedUserDto {
+  @ApiProperty({
+    description: 'Unique user identifier.',
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'User email address.',
+    example: 'student@nti.sk',
+  })
+  email!: string;
+
+  @ApiProperty({
+    description: 'Current user role used for authorization.',
+    enum: UserRole,
+    enumName: 'UserRole',
+    example: UserRole.STUDENT,
+  })
+  role!: UserRole;
+
+  @ApiProperty({
+    description: 'Current account status.',
+    enum: UserStatus,
+    enumName: 'UserStatus',
+    example: UserStatus.PENDING,
+  })
+  status!: UserStatus;
+
+  @ApiPropertyOptional({
+    description:
+      'Refresh token identifier. Present only when the request is authenticated using the refresh token cookie.',
+    example: '8d1524ca-4b6c-4446-b393-e13f5b8867c1',
+  })
+  refreshTokenId?: string;
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,9 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MinLength, MaxLength } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({
+    description: 'Email used to sign in.',
+    example: 'student@nti.sk',
+  })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    description: 'Account password.',
+    example: 'StrongPass123!',
+    minLength: 6,
+    maxLength: 100,
+  })
   @IsString()
   @MinLength(6)
   @MaxLength(100)

--- a/src/auth/dto/logout-response.dto.ts
+++ b/src/auth/dto/logout-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LogoutResponseDto {
+  @ApiProperty({
+    description: 'Indicates successful logout.',
+    example: true,
+  })
+  success!: true;
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,14 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MinLength, MaxLength } from 'class-validator';
 
 export class RegisterDto {
+  @ApiProperty({
+    description: 'Email for the new account.',
+    example: 'new.student@nti.sk',
+  })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    description: 'Display name of the new user.',
+    example: 'Jan Novak',
+    minLength: 2,
+    maxLength: 50,
+  })
   @IsString()
   @MinLength(2)
   @MaxLength(50)
   name!: string;
 
+  @ApiProperty({
+    description: 'Password for the new account.',
+    example: 'StrongPass123!',
+    minLength: 8,
+    maxLength: 100,
+  })
   @IsString()
   @MinLength(8)
   @MaxLength(100)

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,30 @@ async function bootstrap() {
   // Swagger
   const swaggerConfig = new DocumentBuilder()
     .setTitle('NTI Backend')
-    .setDescription('NTI Backend API')
+    .setDescription(
+      'API for NTI platform workflows, authentication, and administrative operations.',
+    )
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description:
+          'Use the access token returned by the authentication endpoints.',
+      },
+      'access-token',
+    )
+    .addCookieAuth(
+      'refreshToken',
+      {
+        type: 'apiKey',
+        in: 'cookie',
+        description:
+          'HttpOnly refresh token cookie used by the refresh and logout endpoints.',
+      },
+      'refresh-token',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('api/docs', app, document);


### PR DESCRIPTION
Improve API docs by adding request/response DTO schemas, field examples, and explicit auth requirements for Bearer access tokens and refresh-token cookies.