### PR TITLE
feat(applications): implement document management features

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,9 @@
       "json",
       "ts"
     ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {

--- a/prisma/migrations/20260502120000_add_program_a_application_documents/migration.sql
+++ b/prisma/migrations/20260502120000_add_program_a_application_documents/migration.sql
@@ -1,0 +1,65 @@
+CREATE TYPE "DocumentType" AS ENUM (
+  'EXECUTIVE_SUMMARY',
+  'TECHNICAL_ARCHITECTURE',
+  'ROADMAP',
+  'BUDGET',
+  'RISK_ANALYSIS',
+  'MONETIZATION_MODEL',
+  'CV',
+  'MOTIVATION_LETTER',
+  'SOLUTION_PROPOSAL',
+  'OTHER'
+);
+
+CREATE TYPE "ApplicationDocumentScope" AS ENUM ('APPLICATION', 'TEAM_MEMBER');
+
+CREATE TABLE "RequiredDocumentType" (
+  "id" TEXT NOT NULL,
+  "callId" TEXT NOT NULL,
+  "documentType" "DocumentType" NOT NULL,
+  "isRequired" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "RequiredDocumentType_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ApplicationDocument" (
+  "id" TEXT NOT NULL,
+  "applicationId" TEXT NOT NULL,
+  "uploadedFileId" TEXT NOT NULL,
+  "documentType" "DocumentType" NOT NULL,
+  "documentScope" "ApplicationDocumentScope" NOT NULL,
+  "memberUserId" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 1,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdById" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ApplicationDocument_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RequiredDocumentType_callId_documentType_key" ON "RequiredDocumentType"("callId", "documentType");
+CREATE INDEX "RequiredDocumentType_callId_isRequired_idx" ON "RequiredDocumentType"("callId", "isRequired");
+CREATE INDEX "ApplicationDocument_applicationId_documentType_isActive_idx" ON "ApplicationDocument"("applicationId", "documentType", "isActive");
+CREATE INDEX "ApplicationDocument_applicationId_documentScope_isActive_idx" ON "ApplicationDocument"("applicationId", "documentScope", "isActive");
+CREATE INDEX "ApplicationDocument_applicationId_memberUserId_documentType_isActive_idx" ON "ApplicationDocument"("applicationId", "memberUserId", "documentType", "isActive");
+CREATE INDEX "ApplicationDocument_uploadedFileId_idx" ON "ApplicationDocument"("uploadedFileId");
+
+ALTER TABLE "RequiredDocumentType"
+  ADD CONSTRAINT "RequiredDocumentType_callId_fkey"
+  FOREIGN KEY ("callId") REFERENCES "Call"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationDocument"
+  ADD CONSTRAINT "ApplicationDocument_applicationId_fkey"
+  FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationDocument"
+  ADD CONSTRAINT "ApplicationDocument_uploadedFileId_fkey"
+  FOREIGN KEY ("uploadedFileId") REFERENCES "UploadedFile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationDocument"
+  ADD CONSTRAINT "ApplicationDocument_memberUserId_fkey"
+  FOREIGN KEY ("memberUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationDocument"
+  ADD CONSTRAINT "ApplicationDocument_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260502120000_add_program_a_application_documents/migration.sql
+++ b/prisma/migrations/20260502120000_add_program_a_application_documents/migration.sql
@@ -43,6 +43,12 @@ CREATE INDEX "ApplicationDocument_applicationId_documentType_isActive_idx" ON "A
 CREATE INDEX "ApplicationDocument_applicationId_documentScope_isActive_idx" ON "ApplicationDocument"("applicationId", "documentScope", "isActive");
 CREATE INDEX "ApplicationDocument_applicationId_memberUserId_documentType_isActive_idx" ON "ApplicationDocument"("applicationId", "memberUserId", "documentType", "isActive");
 CREATE INDEX "ApplicationDocument_uploadedFileId_idx" ON "ApplicationDocument"("uploadedFileId");
+CREATE UNIQUE INDEX "ApplicationDocument_active_application_slot_key"
+  ON "ApplicationDocument"("applicationId", "documentType", "documentScope")
+  WHERE "isActive" = true AND "memberUserId" IS NULL;
+CREATE UNIQUE INDEX "ApplicationDocument_active_team_member_slot_key"
+  ON "ApplicationDocument"("applicationId", "documentType", "documentScope", "memberUserId")
+  WHERE "isActive" = true AND "memberUserId" IS NOT NULL;
 
 ALTER TABLE "RequiredDocumentType"
   ADD CONSTRAINT "RequiredDocumentType_callId_fkey"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,24 @@ enum ApplicationStatus {
   ARCHIVED
 }
 
+enum DocumentType {
+  EXECUTIVE_SUMMARY
+  TECHNICAL_ARCHITECTURE
+  ROADMAP
+  BUDGET
+  RISK_ANALYSIS
+  MONETIZATION_MODEL
+  CV
+  MOTIVATION_LETTER
+  SOLUTION_PROPOSAL
+  OTHER
+}
+
+enum ApplicationDocumentScope {
+  APPLICATION
+  TEAM_MEMBER
+}
+
 enum DegreeLevel {
   BACHELOR
   MASTER
@@ -156,7 +174,9 @@ model User {
 
   uploads UploadedFile[]
 
-  applicationsCreated Application[] @relation("ApplicationCreatedBy")
+  applicationsCreated           Application[]         @relation("ApplicationCreatedBy")
+  applicationDocumentsCreated   ApplicationDocument[] @relation("ApplicationDocumentCreatedBy")
+  applicationDocumentsForMember ApplicationDocument[] @relation("ApplicationDocumentMember")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -188,10 +208,11 @@ model UploadedFile {
   uploadedAt         DateTime?
   failedAt           DateTime?
 
-  createdAt           DateTime         @default(now())
-  updatedAt           DateTime         @updatedAt
-  academicEvidenceFor StudentProfile[] @relation("StudentAcademicEvidence")
-  cvFor               StudentProfile[] @relation("StudentCvFile")
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  academicEvidenceFor  StudentProfile[]      @relation("StudentAcademicEvidence")
+  cvFor                StudentProfile[]      @relation("StudentCvFile")
+  applicationDocuments ApplicationDocument[]
 
   @@index([ownerId, status])
   @@index([status, uploadUrlExpiresAt])
@@ -241,8 +262,9 @@ model Call {
 
   applications Application[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
+  requiredDocumentTypes RequiredDocumentType[]
 
   @@index([type, status])
   @@index([status, opensAt, closesAt])
@@ -258,7 +280,8 @@ model Application {
   team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   createdById String
-  createdBy   User   @relation("ApplicationCreatedBy", fields: [createdById], references: [id])
+  createdBy   User                  @relation("ApplicationCreatedBy", fields: [createdById], references: [id])
+  documents   ApplicationDocument[]
 
   status      ApplicationStatus @default(DRAFT)
   submittedAt DateTime?
@@ -270,6 +293,51 @@ model Application {
   @@index([callId, status])
   @@index([teamId, status])
   @@index([createdById, status])
+}
+
+model RequiredDocumentType {
+  id String @id @default(uuid())
+
+  callId String
+  call   Call   @relation(fields: [callId], references: [id], onDelete: Cascade)
+
+  documentType DocumentType
+  isRequired   Boolean      @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([callId, documentType])
+  @@index([callId, isRequired])
+}
+
+model ApplicationDocument {
+  id String @id @default(uuid())
+
+  applicationId String
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+
+  uploadedFileId String
+  uploadedFile   UploadedFile @relation(fields: [uploadedFileId], references: [id], onDelete: Cascade)
+
+  documentType  DocumentType
+  documentScope ApplicationDocumentScope
+
+  memberUserId String?
+  memberUser   User?   @relation("ApplicationDocumentMember", fields: [memberUserId], references: [id], onDelete: Cascade)
+
+  version  Int     @default(1)
+  isActive Boolean @default(true)
+
+  createdById String
+  createdBy   User   @relation("ApplicationDocumentCreatedBy", fields: [createdById], references: [id])
+
+  createdAt DateTime @default(now())
+
+  @@index([applicationId, documentType, isActive])
+  @@index([applicationId, documentScope, isActive])
+  @@index([applicationId, memberUserId, documentType, isActive])
+  @@index([uploadedFileId])
 }
 
 enum InvitationStatus {

--- a/prisma/seed/seeds/002-calls.seed.ts
+++ b/prisma/seed/seeds/002-calls.seed.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import type { SeedTask } from '../types';
 
+type CallRow = {
+  id: string;
+};
+
 export const callsSeed: SeedTask = {
   name: '002-calls',
   async run(context) {
@@ -32,7 +36,7 @@ export const callsSeed: SeedTask = {
     ];
 
     for (const call of calls) {
-      const existingCall = await context.client.query(
+      const existingCall = await context.client.query<CallRow>(
         'SELECT id FROM "Call" WHERE type = $1 LIMIT 1',
         [call.type],
       );
@@ -54,6 +58,38 @@ export const callsSeed: SeedTask = {
           call.createdAt,
           call.updatedAt,
         ],
+      );
+    }
+
+    const programACall = await context.client.query<CallRow>(
+      'SELECT id FROM "Call" WHERE type = $1 LIMIT 1',
+      ['PROGRAM_A'],
+    );
+
+    const programACallId = programACall.rows[0]?.id;
+
+    if (!programACallId) {
+      return;
+    }
+
+    const requiredDocumentTypes = [
+      'EXECUTIVE_SUMMARY',
+      'TECHNICAL_ARCHITECTURE',
+      'ROADMAP',
+      'BUDGET',
+      'RISK_ANALYSIS',
+      'MONETIZATION_MODEL',
+      'CV',
+      'MOTIVATION_LETTER',
+      'SOLUTION_PROPOSAL',
+    ];
+
+    for (const documentType of requiredDocumentTypes) {
+      await context.client.query(
+        `INSERT INTO "RequiredDocumentType" (id, "callId", "documentType", "isRequired", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT ("callId", "documentType") DO NOTHING`,
+        [randomUUID(), programACallId, documentType, true, now, now],
       );
     }
   },

--- a/src/applications/api-docs/applications-api-docs.decorators.ts
+++ b/src/applications/api-docs/applications-api-docs.decorators.ts
@@ -8,7 +8,11 @@ import {
 } from '@nestjs/swagger';
 import { createApiDecorator } from '../../infrastructure/api-docs/api-docs-factory';
 import { ApplicationDetailDto } from '../dto/application-detail.dto';
+import { ApplicationDocumentDto } from '../dto/application-document.dto';
+import { AttachApplicationDocumentDto } from '../dto/attach-application-document.dto';
 import { CreateApplicationDto } from '../dto/create-application.dto';
+import { DocumentCompletenessDto } from '../dto/document-completeness.dto';
+import { RequiredDocumentsResponseDto } from '../dto/required-documents-response.dto';
 
 export const CreateApplicationApi = () =>
   createApiDecorator({
@@ -55,6 +59,98 @@ export const GetApplicationApi = () =>
         description: 'Invalid application id format.',
       }),
       ApiForbiddenResponse({ description: 'Insufficient permissions.' }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const GetRequiredDocumentsApi = () =>
+  createApiDecorator({
+    summary: 'Get required documents for call',
+    description:
+      'Returns the configured required document types for a call. Program B calls return an empty requiredDocuments list.',
+    successResponse: {
+      status: 200,
+      type: RequiredDocumentsResponseDto,
+      description: 'Required document configuration for the call.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({ description: 'Invalid call id format.' }),
+      ApiNotFoundResponse({ description: 'Call was not found.' }),
+    ],
+  });
+
+export const AttachApplicationDocumentApi = () =>
+  createApiDecorator({
+    summary: 'Attach application document',
+    description:
+      'Attaches an already uploaded file to an application document slot. Team lead only. CV attachments require memberUserId and count per team member.',
+    body: AttachApplicationDocumentDto,
+    successResponse: {
+      status: 201,
+      type: ApplicationDocumentDto,
+      description: 'Document attachment was created successfully.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description: 'Invalid file ownership, upload state, or document scope.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only the team lead may manage application documents.',
+      }),
+      ApiConflictResponse({
+        description:
+          'Application document pack is not supported for this application.',
+      }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const GetApplicationDocumentCompletenessApi = () =>
+  createApiDecorator({
+    summary: 'Get application document completeness',
+    description:
+      'Returns the exact required document slots that are satisfied or missing for the application.',
+    successResponse: {
+      status: 200,
+      type: DocumentCompletenessDto,
+      description: 'Document completeness result for the application.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description: 'Invalid application id format.',
+      }),
+      ApiForbiddenResponse({ description: 'Insufficient permissions.' }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const SubmitApplicationApi = () =>
+  createApiDecorator({
+    summary: 'Submit application',
+    description:
+      'Submits a draft application. Program A submissions require a complete document pack. Successful submission locks the team.',
+    successResponse: {
+      status: 200,
+      type: ApplicationDetailDto,
+      description: 'Application was submitted successfully.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({ description: 'Invalid application id format.' }),
+      ApiForbiddenResponse({
+        description: 'Only the team lead may submit the application.',
+      }),
+      ApiConflictResponse({
+        description:
+          'Application is not in a submittable state or required documents are missing.',
+      }),
       ApiNotFoundResponse({ description: 'Application was not found.' }),
     ],
   });

--- a/src/applications/api-docs/applications-api-docs.decorators.ts
+++ b/src/applications/api-docs/applications-api-docs.decorators.ts
@@ -103,7 +103,7 @@ export const AttachApplicationDocumentApi = () =>
       }),
       ApiConflictResponse({
         description:
-          'Application document pack is not supported for this application.',
+          'Application document pack is not supported for this application, the application is not draft, or another document update won the slot concurrently.',
       }),
       ApiNotFoundResponse({ description: 'Application was not found.' }),
     ],
@@ -143,7 +143,10 @@ export const SubmitApplicationApi = () =>
     extraDecorators: [ApiBearerAuth('access-token')],
     errors: [
       ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
-      ApiBadRequestResponse({ description: 'Invalid application id format.' }),
+      ApiBadRequestResponse({
+        description:
+          'Invalid application id format, or the call is outside its application window.',
+      }),
       ApiForbiddenResponse({
         description: 'Only the team lead may submit the application.',
       }),

--- a/src/applications/api-docs/applications-api-docs.decorators.ts
+++ b/src/applications/api-docs/applications-api-docs.decorators.ts
@@ -145,14 +145,14 @@ export const SubmitApplicationApi = () =>
       ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
       ApiBadRequestResponse({
         description:
-          'Invalid application id format, or the call is outside its application window.',
+          'Invalid application id format, or the call is outside its opensAt/closesAt application window.',
       }),
       ApiForbiddenResponse({
         description: 'Only the team lead may submit the application.',
       }),
       ApiConflictResponse({
         description:
-          'Application is not in a submittable state or required documents are missing.',
+          'Call is not open for applications, application is not in a submittable state, or required documents are missing.',
       }),
       ApiNotFoundResponse({ description: 'Application was not found.' }),
     ],

--- a/src/applications/api-docs/index.ts
+++ b/src/applications/api-docs/index.ts
@@ -1,2 +1,8 @@
-export { CreateApplicationApi } from './applications-api-docs.decorators';
-export { GetApplicationApi } from './applications-api-docs.decorators';
+export {
+  AttachApplicationDocumentApi,
+  CreateApplicationApi,
+  GetApplicationApi,
+  GetApplicationDocumentCompletenessApi,
+  GetRequiredDocumentsApi,
+  SubmitApplicationApi,
+} from './applications-api-docs.decorators';

--- a/src/applications/application-documents.repository.ts
+++ b/src/applications/application-documents.repository.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  ApplicationDocument,
+  Prisma,
+} from '../../generated/prisma/client';
+import { BaseRepository, PrismaDbClient } from '../infrastructure/database';
+import { PrismaService } from '../infrastructure/database/prisma.service';
+
+export type ApplicationDocumentWithFile = Prisma.ApplicationDocumentGetPayload<{
+  select: ReturnType<ApplicationDocumentsRepository['documentWithFileSelect']>;
+}>;
+
+@Injectable()
+export class ApplicationDocumentsRepository extends BaseRepository<
+  ApplicationDocument,
+  Prisma.ApplicationDocumentUncheckedCreateInput,
+  Prisma.ApplicationDocumentUncheckedUpdateInput,
+  Prisma.ApplicationDocumentWhereInput,
+  Prisma.ApplicationDocumentWhereUniqueInput,
+  Prisma.ApplicationDocumentOrderByWithRelationInput
+> {
+  constructor(prisma: PrismaService) {
+    super(prisma);
+  }
+
+  protected getDelegate(db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).applicationDocument;
+  }
+
+  findActiveBySlot(
+    applicationId: string,
+    documentType: Prisma.ApplicationDocumentUncheckedCreateInput['documentType'],
+    documentScope: Prisma.ApplicationDocumentUncheckedCreateInput['documentScope'],
+    memberUserId: string | null,
+    db?: PrismaDbClient,
+  ): Promise<ApplicationDocumentWithFile | null> {
+    return (db ?? this.prisma.client).applicationDocument.findFirst({
+      where: {
+        applicationId,
+        documentType,
+        documentScope,
+        memberUserId,
+        isActive: true,
+      },
+      orderBy: {
+        version: 'desc',
+      },
+      select: this.documentWithFileSelect(),
+    });
+  }
+
+  findLatestVersionNumberBySlot(
+    applicationId: string,
+    documentType: Prisma.ApplicationDocumentUncheckedCreateInput['documentType'],
+    documentScope: Prisma.ApplicationDocumentUncheckedCreateInput['documentScope'],
+    memberUserId: string | null,
+    db?: PrismaDbClient,
+  ): Promise<{ version: number } | null> {
+    return (db ?? this.prisma.client).applicationDocument.findFirst({
+      where: {
+        applicationId,
+        documentType,
+        documentScope,
+        memberUserId,
+      },
+      orderBy: {
+        version: 'desc',
+      },
+      select: {
+        version: true,
+      },
+    });
+  }
+
+  deactivateActiveBySlot(
+    applicationId: string,
+    documentType: Prisma.ApplicationDocumentUncheckedCreateInput['documentType'],
+    documentScope: Prisma.ApplicationDocumentUncheckedCreateInput['documentScope'],
+    memberUserId: string | null,
+    db?: PrismaDbClient,
+  ) {
+    return this.updateMany(
+      {
+        applicationId,
+        documentType,
+        documentScope,
+        memberUserId,
+        isActive: true,
+      },
+      {
+        isActive: false,
+      },
+      db,
+    );
+  }
+
+  createVersioned(
+    data: Prisma.ApplicationDocumentUncheckedCreateInput,
+    db?: PrismaDbClient,
+  ): Promise<ApplicationDocumentWithFile> {
+    return (db ?? this.prisma.client).applicationDocument.create({
+      data,
+      select: this.documentWithFileSelect(),
+    });
+  }
+
+  private documentWithFileSelect() {
+    return {
+      id: true,
+      applicationId: true,
+      uploadedFileId: true,
+      documentType: true,
+      documentScope: true,
+      memberUserId: true,
+      version: true,
+      isActive: true,
+      createdById: true,
+      createdAt: true,
+      uploadedFile: {
+        select: {
+          id: true,
+          ownerId: true,
+          key: true,
+          originalName: true,
+          mimeType: true,
+          size: true,
+          visibility: true,
+          status: true,
+          uploadedAt: true,
+        },
+      },
+    } as const;
+  }
+}

--- a/src/applications/application-rules.service.ts
+++ b/src/applications/application-rules.service.ts
@@ -34,7 +34,7 @@ export class ApplicationRulesService {
       throw new NotFoundException('Call not found');
     }
 
-    this.validateCallOpenForApplications(call);
+    this.ensureCallOpenForApplications(call);
 
     // 2. Verify team exists and is not archived
     const team = await this.teamRepository.findPublicById(teamId, db);
@@ -57,7 +57,9 @@ export class ApplicationRulesService {
     }
   }
 
-  private validateCallOpenForApplications(call: Call): void {
+  ensureCallOpenForApplications(
+    call: Pick<Call, 'status' | 'opensAt' | 'closesAt'>,
+  ): void {
     // Check call status
     if (call.status !== CallStatus.OPEN) {
       throw new ConflictException(

--- a/src/applications/applications.controller.spec.ts
+++ b/src/applications/applications.controller.spec.ts
@@ -14,12 +14,21 @@ describe('ApplicationsController', () => {
   let applicationsService: {
     createDraft: jest.Mock;
     findById: jest.Mock;
+    attachDocument: jest.Mock;
+    getDocumentCompleteness: jest.Mock;
+    submit: jest.Mock;
   };
 
   beforeEach(() => {
     applicationsService = {
       createDraft: jest.fn().mockResolvedValue({ id: 'application-1' }),
       findById: jest.fn().mockResolvedValue({ id: 'application-1' }),
+      attachDocument: jest.fn().mockResolvedValue({ id: 'document-1' }),
+      getDocumentCompleteness: jest.fn().mockResolvedValue({
+        applicationId: 'application-1',
+        isComplete: true,
+      }),
+      submit: jest.fn().mockResolvedValue({ id: 'application-1' }),
     };
 
     controller = new ApplicationsController(
@@ -49,6 +58,50 @@ describe('ApplicationsController', () => {
 
     expect(applicationsService.findById).toHaveBeenCalledWith(
       'f6c90688-c973-40ca-8f3b-c55667cc6f77',
+      user,
+    );
+    expect(result).toEqual({ id: 'application-1' });
+  });
+
+  it('delegates document attachment', async () => {
+    const user = { id: 'user-1', email: 'lead@example.com' } as never;
+    const dto = { fileId: 'file-1', documentType: 'BUDGET' } as never;
+
+    const result = await controller.attachDocument('application-1', user, dto);
+
+    expect(applicationsService.attachDocument).toHaveBeenCalledWith(
+      'application-1',
+      user,
+      dto,
+    );
+    expect(result).toEqual({ id: 'document-1' });
+  });
+
+  it('delegates completeness lookup', async () => {
+    const user = { id: 'user-1', email: 'lead@example.com' } as never;
+
+    const result = await controller.getDocumentCompleteness(
+      'application-1',
+      user,
+    );
+
+    expect(applicationsService.getDocumentCompleteness).toHaveBeenCalledWith(
+      'application-1',
+      user,
+    );
+    expect(result).toEqual({
+      applicationId: 'application-1',
+      isComplete: true,
+    });
+  });
+
+  it('delegates submission', async () => {
+    const user = { id: 'user-1', email: 'lead@example.com' } as never;
+
+    const result = await controller.submit('application-1', user);
+
+    expect(applicationsService.submit).toHaveBeenCalledWith(
+      'application-1',
       user,
     );
     expect(result).toEqual({ id: 'application-1' });

--- a/src/applications/applications.controller.ts
+++ b/src/applications/applications.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseUUIDPipe,
   Post,
@@ -11,9 +13,18 @@ import { ApiTags } from '@nestjs/swagger';
 import { GetUserContext } from '../auth/decorators/get-user-context.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import type { AuthenticatedUserContext } from '../common/types/auth-user-context.type';
-import { CreateApplicationApi, GetApplicationApi } from './api-docs';
+import {
+  AttachApplicationDocumentApi,
+  CreateApplicationApi,
+  GetApplicationApi,
+  GetApplicationDocumentCompletenessApi,
+  SubmitApplicationApi,
+} from './api-docs';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
+import { ApplicationDocumentDto } from './dto/application-document.dto';
+import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
+import { DocumentCompletenessDto } from './dto/document-completeness.dto';
 import { ApplicationsService } from './applications.service';
 
 @ApiTags('Applications')
@@ -38,5 +49,34 @@ export class ApplicationsController {
     @GetUserContext() user: AuthenticatedUserContext,
   ): Promise<ApplicationDetailDto> {
     return this.applicationsService.findById(id, user);
+  }
+
+  @AttachApplicationDocumentApi()
+  @Post(':id/documents')
+  attachDocument(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: AttachApplicationDocumentDto,
+  ): Promise<ApplicationDocumentDto> {
+    return this.applicationsService.attachDocument(id, user, dto);
+  }
+
+  @GetApplicationDocumentCompletenessApi()
+  @Get(':id/document-completeness')
+  getDocumentCompleteness(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<DocumentCompletenessDto> {
+    return this.applicationsService.getDocumentCompleteness(id, user);
+  }
+
+  @SubmitApplicationApi()
+  @HttpCode(HttpStatus.OK)
+  @Post(':id/submit')
+  submit(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<ApplicationDetailDto> {
+    return this.applicationsService.submit(id, user);
   }
 }

--- a/src/applications/applications.module.ts
+++ b/src/applications/applications.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { FilesModule } from '../files/files.module';
+import { CallsDocumentsController } from './calls-documents.controller';
 import { ApplicationsController } from './applications.controller';
+import { ApplicationDocumentsRepository } from './application-documents.repository';
 import { ApplicationRulesService } from './application-rules.service';
 import { ApplicationsRepository } from './applications.repository';
 import { ApplicationsService } from './applications.service';
@@ -8,10 +11,11 @@ import { CallsRepository } from './calls.repository';
 import { TeamModule } from '../team/team.module';
 
 @Module({
-  imports: [AuthModule, TeamModule],
-  controllers: [ApplicationsController],
+  imports: [AuthModule, TeamModule, FilesModule],
+  controllers: [ApplicationsController, CallsDocumentsController],
   providers: [
     ApplicationsRepository,
+    ApplicationDocumentsRepository,
     CallsRepository,
     ApplicationRulesService,
     ApplicationsService,

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -8,6 +8,10 @@ export type ApplicationWithRelations = Prisma.ApplicationGetPayload<{
   select: ReturnType<ApplicationsRepository['applicationDetailSelect']>;
 }>;
 
+export type ApplicationWorkflowView = Prisma.ApplicationGetPayload<{
+  select: ReturnType<ApplicationsRepository['applicationWorkflowSelect']>;
+}>;
+
 @Injectable()
 export class ApplicationsRepository extends BaseRepository<
   Application,
@@ -32,6 +36,16 @@ export class ApplicationsRepository extends BaseRepository<
     return (db ?? this.prisma.client).application.findUnique({
       where: { id },
       select: this.applicationDetailSelect(),
+    });
+  }
+
+  findByIdForWorkflow(
+    id: string,
+    db?: PrismaDbClient,
+  ): Promise<ApplicationWorkflowView | null> {
+    return (db ?? this.prisma.client).application.findUnique({
+      where: { id },
+      select: this.applicationWorkflowSelect(),
     });
   }
 
@@ -69,6 +83,21 @@ export class ApplicationsRepository extends BaseRepository<
         status: true,
       },
     });
+  }
+
+  submitDraft(
+    id: string,
+    submittedAt: Date,
+    db?: PrismaDbClient,
+  ): Promise<Application> {
+    return this.update(
+      { id },
+      {
+        status: ApplicationStatus.SUBMITTED,
+        submittedAt,
+      },
+      db,
+    );
   }
 
   private applicationDetailSelect() {
@@ -113,6 +142,69 @@ export class ApplicationsRepository extends BaseRepository<
           email: true,
           role: true,
           status: true,
+        },
+      },
+    } as const;
+  }
+
+  private applicationWorkflowSelect() {
+    return {
+      id: true,
+      callId: true,
+      teamId: true,
+      createdById: true,
+      status: true,
+      submittedAt: true,
+      decidedAt: true,
+      createdAt: true,
+      updatedAt: true,
+      call: {
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          status: true,
+          opensAt: true,
+          closesAt: true,
+          requiredDocumentTypes: {
+            where: {
+              isRequired: true,
+            },
+            select: {
+              id: true,
+              documentType: true,
+              isRequired: true,
+            },
+          },
+        },
+      },
+      team: {
+        select: {
+          id: true,
+          name: true,
+          leaderId: true,
+          lockedAt: true,
+          archivedAt: true,
+          members: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      },
+      documents: {
+        where: {
+          isActive: true,
+        },
+        select: {
+          id: true,
+          documentType: true,
+          documentScope: true,
+          memberUserId: true,
+          version: true,
+          isActive: true,
+          uploadedFileId: true,
+          createdAt: true,
         },
       },
     } as const;

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -175,6 +175,9 @@ export class ApplicationsRepository extends BaseRepository<
               documentType: true,
               isRequired: true,
             },
+            orderBy: {
+              documentType: 'asc',
+            },
           },
         },
       },

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -2,16 +2,40 @@ jest.mock('./applications.repository', () => ({
   ApplicationsRepository: class ApplicationsRepository {},
 }));
 
+jest.mock('./application-documents.repository', () => ({
+  ApplicationDocumentsRepository: class ApplicationDocumentsRepository {},
+}));
+
 jest.mock('./application-rules.service', () => ({
   ApplicationRulesService: class ApplicationRulesService {},
 }));
 
+jest.mock('./calls.repository', () => ({
+  CallsRepository: class CallsRepository {},
+}));
+
+jest.mock('../team/team.repository', () => ({
+  TeamRepository: class TeamRepository {},
+}));
+
+jest.mock('../files/files.repository', () => ({
+  FilesRepository: class FilesRepository {},
+}));
+
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { ApplicationStatus, UserRole } from '../../generated/prisma/enums';
+import {
+  ApplicationDocumentScope,
+  ApplicationStatus,
+  DocumentType,
+  ProgramType,
+  UploadStatus,
+  UserRole,
+} from '../../generated/prisma/enums';
 import { ApplicationsService } from './applications.service';
 
 describe('ApplicationsService', () => {
@@ -20,27 +44,91 @@ describe('ApplicationsService', () => {
     findActiveByTeamAndCall: jest.Mock;
     createDraft: jest.Mock;
     findByIdWithRelations: jest.Mock;
+    findByIdForWorkflow: jest.Mock;
+    submitDraft: jest.Mock;
     transaction: jest.Mock;
+  };
+  let applicationDocumentsRepository: {
+    deactivateActiveBySlot: jest.Mock;
+    findLatestVersionNumberBySlot: jest.Mock;
+    createVersioned: jest.Mock;
   };
   let applicationRulesService: {
     validateApplicationCreationRules: jest.Mock;
+    ensureCallOpenForApplications: jest.Mock;
+  };
+  let callsRepository: {
+    findByIdWithRequiredDocumentTypes: jest.Mock;
+  };
+  let teamRepository: {
+    update: jest.Mock;
+  };
+  let filesRepository: {
+    findByIdForOwners: jest.Mock;
   };
 
   const mockCall = {
     id: 'call-1',
-    type: 'PROGRAM_A',
+    type: ProgramType.PROGRAM_A,
     title: 'Test Call',
     status: 'OPEN',
     opensAt: new Date('2026-04-10T00:00:00.000Z'),
     closesAt: new Date('2026-04-30T23:59:59.000Z'),
+    requiredDocumentTypes: [
+      { id: 'req-1', documentType: DocumentType.BUDGET, isRequired: true },
+      { id: 'req-2', documentType: DocumentType.CV, isRequired: true },
+      {
+        id: 'req-3',
+        documentType: DocumentType.MOTIVATION_LETTER,
+        isRequired: true,
+      },
+    ],
   };
 
   const mockTeam = {
     id: 'team-1',
     name: 'Test Team',
     leaderId: 'user-1',
+    lockedAt: null,
     archivedAt: null,
     members: [{ userId: 'user-1' }, { userId: 'user-2' }],
+  };
+
+  const workflowApplication = {
+    id: 'application-1',
+    callId: 'call-1',
+    teamId: 'team-1',
+    createdById: 'user-1',
+    status: ApplicationStatus.DRAFT,
+    submittedAt: null,
+    decidedAt: null,
+    createdAt: new Date('2026-04-20T12:00:00.000Z'),
+    updatedAt: new Date('2026-04-20T12:00:00.000Z'),
+    call: mockCall,
+    team: mockTeam,
+    documents: [],
+  };
+
+  const detailApplication = {
+    id: 'application-1',
+    callId: 'call-1',
+    teamId: 'team-1',
+    createdById: 'user-1',
+    status: ApplicationStatus.DRAFT,
+    submittedAt: null,
+    decidedAt: null,
+    createdAt: new Date('2026-04-20T12:00:00.000Z'),
+    updatedAt: new Date('2026-04-20T12:00:00.000Z'),
+    call: mockCall,
+    team: mockTeam,
+    createdBy: {
+      id: 'user-1',
+      firstName: 'John',
+      lastName: 'Lead',
+      email: 'lead@example.com',
+      role: UserRole.STUDENT,
+      status: 'ACTIVE',
+    },
   };
 
   beforeEach(() => {
@@ -48,42 +136,51 @@ describe('ApplicationsService', () => {
       findActiveByTeamAndCall: jest.fn(),
       createDraft: jest.fn(),
       findByIdWithRelations: jest.fn(),
-      transaction: jest.fn(),
+      findByIdForWorkflow: jest.fn(),
+      submitDraft: jest.fn(),
+      transaction: jest.fn((fn: (db: never) => Promise<unknown>) =>
+        fn({ tx: 'db-client' } as never),
+      ),
+    };
+
+    applicationDocumentsRepository = {
+      deactivateActiveBySlot: jest.fn().mockResolvedValue(undefined),
+      findLatestVersionNumberBySlot: jest
+        .fn()
+        .mockResolvedValue({ version: 1 }),
+      createVersioned: jest.fn(),
     };
 
     applicationRulesService = {
-      validateApplicationCreationRules: jest.fn().mockResolvedValue({
-        call: mockCall,
-        team: mockTeam,
-      }),
+      validateApplicationCreationRules: jest.fn().mockResolvedValue(undefined),
+      ensureCallOpenForApplications: jest.fn(),
+    };
+
+    callsRepository = {
+      findByIdWithRequiredDocumentTypes: jest.fn(),
+    };
+
+    teamRepository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    filesRepository = {
+      findByIdForOwners: jest.fn(),
     };
 
     service = new ApplicationsService(
       applicationsRepository as never,
+      applicationDocumentsRepository as never,
       applicationRulesService as never,
+      callsRepository as never,
+      teamRepository as never,
+      filesRepository as never,
     );
   });
 
   it('validates rules before creating draft application', async () => {
-    const transactionClient = { tx: 'db-client' } as never;
-
-    applicationsRepository.transaction.mockImplementation(
-      (fn: (db: never) => Promise<unknown>) => {
-        applicationsRepository.findActiveByTeamAndCall.mockResolvedValue(null);
-        applicationsRepository.createDraft.mockResolvedValue({
-          id: 'application-1',
-          callId: 'call-1',
-          teamId: 'team-1',
-          createdById: 'user-1',
-          status: ApplicationStatus.DRAFT,
-          submittedAt: null,
-          decidedAt: null,
-          createdAt: new Date('2026-04-20T12:00:00.000Z'),
-          updatedAt: new Date('2026-04-20T12:00:00.000Z'),
-        });
-        return fn(transactionClient);
-      },
-    );
+    applicationsRepository.findActiveByTeamAndCall.mockResolvedValue(null);
+    applicationsRepository.createDraft.mockResolvedValue(detailApplication);
 
     const result = await service.createDraft(
       { id: 'user-1', email: 'lead@example.com' } as never,
@@ -92,103 +189,175 @@ describe('ApplicationsService', () => {
 
     expect(
       applicationRulesService.validateApplicationCreationRules,
-    ).toHaveBeenCalledWith('call-1', 'team-1', 'user-1', transactionClient);
-    expect(applicationsRepository.findActiveByTeamAndCall).toHaveBeenCalledWith(
-      'team-1',
-      'call-1',
-      transactionClient,
-    );
-    expect(applicationsRepository.createDraft).toHaveBeenCalledWith(
-      'call-1',
-      'team-1',
-      'user-1',
-      transactionClient,
-    );
+    ).toHaveBeenCalledWith('call-1', 'team-1', 'user-1', { tx: 'db-client' });
     expect(result.id).toBe('application-1');
   });
 
-  it('throws conflict when active duplicate exists inside transaction', async () => {
-    const transactionClient = { tx: 'db-client' } as never;
-
-    applicationsRepository.transaction.mockImplementation(
-      (fn: (db: never) => Promise<unknown>) => {
-        applicationsRepository.findActiveByTeamAndCall.mockResolvedValue({
-          id: 'application-1',
-          status: ApplicationStatus.DRAFT,
-        });
-        return fn(transactionClient);
-      },
+  it('returns required documents for a Program A call', async () => {
+    callsRepository.findByIdWithRequiredDocumentTypes.mockResolvedValue(
+      mockCall,
     );
 
-    await expect(
-      service.createDraft(
-        { id: 'user-1', email: 'lead@example.com' } as never,
-        { callId: 'call-1', teamId: 'team-1' },
-      ),
-    ).rejects.toBeInstanceOf(ConflictException);
+    const result = await service.getRequiredDocumentsForCall('call-1');
 
-    expect(
-      applicationRulesService.validateApplicationCreationRules,
-    ).toHaveBeenCalledWith('call-1', 'team-1', 'user-1', transactionClient);
+    expect(result.requiredDocuments).toHaveLength(3);
+    expect(result.programType).toBe(ProgramType.PROGRAM_A);
   });
 
-  it('maps prisma unique violation to conflict exception for concurrent creates', async () => {
-    applicationsRepository.transaction.mockRejectedValue({ code: 'P2002' });
+  it('throws not found when required-document call does not exist', async () => {
+    callsRepository.findByIdWithRequiredDocumentTypes.mockResolvedValue(null);
 
     await expect(
-      service.createDraft(
-        { id: 'user-1', email: 'lead@example.com' } as never,
-        { callId: 'call-1', teamId: 'team-1' },
-      ),
-    ).rejects.toBeInstanceOf(ConflictException);
-  });
-
-  it('rethrows non-unique transaction errors', async () => {
-    const dbError = new Error('database unavailable');
-    applicationsRepository.transaction.mockRejectedValue(dbError);
-
-    await expect(
-      service.createDraft(
-        { id: 'user-1', email: 'lead@example.com' } as never,
-        { callId: 'call-1', teamId: 'team-1' },
-      ),
-    ).rejects.toThrow('database unavailable');
-  });
-
-  it('throws not found when application does not exist', async () => {
-    applicationsRepository.findByIdWithRelations.mockResolvedValue(null);
-
-    await expect(
-      service.findById('application-404', {
-        id: 'user-1',
-        email: 'user@example.com',
-        role: UserRole.STUDENT,
-      } as never),
+      service.getRequiredDocumentsForCall('missing-call'),
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
-  it('allows admin to view any application', async () => {
-    applicationsRepository.findByIdWithRelations.mockResolvedValue({
-      id: 'application-1',
-      callId: 'call-1',
-      teamId: 'team-1',
+  it('attaches an application-level document for the team lead', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+      workflowApplication,
+    );
+    filesRepository.findByIdForOwners.mockResolvedValue({
+      id: 'file-1',
+      ownerId: 'user-1',
+      status: UploadStatus.UPLOADED,
+    });
+    applicationDocumentsRepository.createVersioned.mockResolvedValue({
+      id: 'doc-1',
+      applicationId: 'application-1',
+      uploadedFileId: 'file-1',
+      documentType: DocumentType.BUDGET,
+      documentScope: ApplicationDocumentScope.APPLICATION,
+      memberUserId: null,
+      version: 2,
+      isActive: true,
       createdById: 'user-1',
-      status: ApplicationStatus.DRAFT,
-      submittedAt: null,
-      decidedAt: null,
-      createdAt: new Date('2026-04-20T12:00:00.000Z'),
-      updatedAt: new Date('2026-04-20T12:00:00.000Z'),
-      call: mockCall,
-      team: mockTeam,
-      createdBy: {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Lead',
-        email: 'lead@example.com',
-        role: UserRole.STUDENT,
-        status: 'ACTIVE',
+      createdAt: new Date('2026-05-02T10:00:00.000Z'),
+      uploadedFile: {
+        id: 'file-1',
+        ownerId: 'user-1',
+        key: 'key',
+        originalName: 'budget.pdf',
+        mimeType: 'application/pdf',
+        size: 1024,
+        visibility: 'PRIVATE',
+        status: UploadStatus.UPLOADED,
+        uploadedAt: new Date('2026-05-02T09:00:00.000Z'),
       },
     });
+
+    const result = await service.attachDocument(
+      'application-1',
+      {
+        id: 'user-1',
+        email: 'lead@example.com',
+        role: UserRole.STUDENT,
+      } as never,
+      { fileId: 'file-1', documentType: DocumentType.BUDGET },
+    );
+
+    expect(filesRepository.findByIdForOwners).toHaveBeenCalledWith(
+      'file-1',
+      ['user-1'],
+      { tx: 'db-client' },
+    );
+    expect(result.documentScope).toBe(ApplicationDocumentScope.APPLICATION);
+    expect(result.version).toBe(2);
+  });
+
+  it('rejects CV attachment without memberUserId', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+      workflowApplication,
+    );
+
+    await expect(
+      service.attachDocument(
+        'application-1',
+        {
+          id: 'user-1',
+          email: 'lead@example.com',
+          role: UserRole.STUDENT,
+        } as never,
+        { fileId: 'file-1', documentType: DocumentType.CV },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects document attachment when application is already submitted', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue({
+      ...workflowApplication,
+      status: ApplicationStatus.SUBMITTED,
+      submittedAt: new Date('2026-05-02T11:00:00.000Z'),
+    });
+
+    await expect(
+      service.attachDocument(
+        'application-1',
+        {
+          id: 'user-1',
+          email: 'lead@example.com',
+          role: UserRole.STUDENT,
+        } as never,
+        { fileId: 'file-1', documentType: DocumentType.BUDGET },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('calculates exact missing Program A documents', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue({
+      ...workflowApplication,
+      documents: [
+        {
+          id: 'doc-1',
+          documentType: DocumentType.BUDGET,
+          documentScope: ApplicationDocumentScope.APPLICATION,
+          memberUserId: null,
+          version: 1,
+          isActive: true,
+          uploadedFileId: 'file-1',
+          createdAt: new Date('2026-05-02T09:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getDocumentCompleteness('application-1', {
+      id: 'user-1',
+      email: 'lead@example.com',
+      role: UserRole.STUDENT,
+    } as never);
+
+    expect(result.isComplete).toBe(false);
+    expect(result.satisfiedDocuments).toEqual([
+      {
+        documentType: DocumentType.BUDGET,
+        documentScope: ApplicationDocumentScope.APPLICATION,
+        memberUserId: null,
+      },
+    ]);
+    expect(result.missingDocuments).toEqual(
+      expect.arrayContaining([
+        {
+          documentType: DocumentType.CV,
+          documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+          memberUserId: 'user-1',
+        },
+        {
+          documentType: DocumentType.CV,
+          documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+          memberUserId: 'user-2',
+        },
+        {
+          documentType: DocumentType.MOTIVATION_LETTER,
+          documentScope: ApplicationDocumentScope.APPLICATION,
+          memberUserId: null,
+        },
+      ]),
+    );
+  });
+
+  it('allows admin to view any application', async () => {
+    applicationsRepository.findByIdWithRelations.mockResolvedValue(
+      detailApplication,
+    );
 
     const result = await service.findById('application-1', {
       id: 'admin-1',
@@ -199,92 +368,10 @@ describe('ApplicationsService', () => {
     expect(result.id).toBe('application-1');
   });
 
-  it('allows team lead to view team application', async () => {
-    applicationsRepository.findByIdWithRelations.mockResolvedValue({
-      id: 'application-1',
-      callId: 'call-1',
-      teamId: 'team-1',
-      createdById: 'user-1',
-      status: ApplicationStatus.DRAFT,
-      submittedAt: null,
-      decidedAt: null,
-      createdAt: new Date('2026-04-20T12:00:00.000Z'),
-      updatedAt: new Date('2026-04-20T12:00:00.000Z'),
-      call: mockCall,
-      team: mockTeam,
-      createdBy: {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Lead',
-        email: 'lead@example.com',
-        role: UserRole.STUDENT,
-        status: 'ACTIVE',
-      },
-    });
-
-    const result = await service.findById('application-1', {
-      id: 'user-1',
-      email: 'lead@example.com',
-      role: UserRole.STUDENT,
-    } as never);
-
-    expect(result.id).toBe('application-1');
-  });
-
-  it('allows team member to view team application', async () => {
-    applicationsRepository.findByIdWithRelations.mockResolvedValue({
-      id: 'application-1',
-      callId: 'call-1',
-      teamId: 'team-1',
-      createdById: 'user-1',
-      status: ApplicationStatus.DRAFT,
-      submittedAt: null,
-      decidedAt: null,
-      createdAt: new Date('2026-04-20T12:00:00.000Z'),
-      updatedAt: new Date('2026-04-20T12:00:00.000Z'),
-      call: mockCall,
-      team: mockTeam,
-      createdBy: {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Lead',
-        email: 'lead@example.com',
-        role: UserRole.STUDENT,
-        status: 'ACTIVE',
-      },
-    });
-
-    const result = await service.findById('application-1', {
-      id: 'user-2',
-      email: 'member@example.com',
-      role: UserRole.STUDENT,
-    } as never);
-
-    expect(result.id).toBe('application-1');
-  });
-
   it('forbids non-team member from viewing application', async () => {
-    applicationsRepository.findByIdWithRelations.mockResolvedValue({
-      id: 'application-1',
-      callId: 'call-1',
-      teamId: 'team-1',
-      createdById: 'user-1',
-      status: ApplicationStatus.DRAFT,
-      submittedAt: null,
-      decidedAt: null,
-      createdAt: new Date('2026-04-20T12:00:00.000Z'),
-      updatedAt: new Date('2026-04-20T12:00:00.000Z'),
-      call: mockCall,
-      team: mockTeam,
-      createdBy: {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Lead',
-        email: 'lead@example.com',
-        role: UserRole.STUDENT,
-        status: 'ACTIVE',
-      },
-    });
+    applicationsRepository.findByIdWithRelations.mockResolvedValue(
+      detailApplication,
+    );
 
     await expect(
       service.findById('application-1', {
@@ -295,21 +382,83 @@ describe('ApplicationsService', () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it('propagates validation errors from rules service', async () => {
-    const validationError = new ForbiddenException('Only team lead can submit');
-    applicationRulesService.validateApplicationCreationRules.mockRejectedValue(
-      validationError,
-    );
+  it('submits a complete draft application and locks the team', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue({
+      ...workflowApplication,
+      documents: [
+        {
+          id: 'doc-1',
+          documentType: DocumentType.BUDGET,
+          documentScope: ApplicationDocumentScope.APPLICATION,
+          memberUserId: null,
+          version: 1,
+          isActive: true,
+          uploadedFileId: 'file-1',
+          createdAt: new Date('2026-05-02T09:00:00.000Z'),
+        },
+        {
+          id: 'doc-2',
+          documentType: DocumentType.CV,
+          documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+          memberUserId: 'user-1',
+          version: 1,
+          isActive: true,
+          uploadedFileId: 'file-2',
+          createdAt: new Date('2026-05-02T09:00:00.000Z'),
+        },
+        {
+          id: 'doc-3',
+          documentType: DocumentType.CV,
+          documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+          memberUserId: 'user-2',
+          version: 1,
+          isActive: true,
+          uploadedFileId: 'file-3',
+          createdAt: new Date('2026-05-02T09:00:00.000Z'),
+        },
+        {
+          id: 'doc-4',
+          documentType: DocumentType.MOTIVATION_LETTER,
+          documentScope: ApplicationDocumentScope.APPLICATION,
+          memberUserId: null,
+          version: 1,
+          isActive: true,
+          uploadedFileId: 'file-4',
+          createdAt: new Date('2026-05-02T09:00:00.000Z'),
+        },
+      ],
+    });
+    applicationsRepository.findByIdWithRelations.mockResolvedValue({
+      ...detailApplication,
+      status: ApplicationStatus.SUBMITTED,
+      submittedAt: new Date('2026-05-02T11:00:00.000Z'),
+    });
 
-    applicationsRepository.transaction.mockImplementation(
-      (fn: (db: never) => Promise<unknown>) => fn({ tx: 'db-client' } as never),
+    const result = await service.submit('application-1', {
+      id: 'user-1',
+      email: 'lead@example.com',
+      role: UserRole.STUDENT,
+    } as never);
+
+    expect(
+      applicationRulesService.ensureCallOpenForApplications,
+    ).toHaveBeenCalledWith(mockCall);
+    expect(applicationsRepository.submitDraft).toHaveBeenCalled();
+    expect(teamRepository.update).toHaveBeenCalled();
+    expect(result.status).toBe(ApplicationStatus.SUBMITTED);
+  });
+
+  it('rejects submit when Program A application is incomplete', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+      workflowApplication,
     );
 
     await expect(
-      service.createDraft(
-        { id: 'user-2', email: 'member@example.com' } as never,
-        { callId: 'call-1', teamId: 'team-1' },
-      ),
-    ).rejects.toThrow('Only team lead can submit');
+      service.submit('application-1', {
+        id: 'user-1',
+        email: 'lead@example.com',
+        role: UserRole.STUDENT,
+      } as never),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -260,8 +260,28 @@ describe('ApplicationsService', () => {
       ['user-1'],
       { tx: 'db-client' },
     );
+    expect(applicationsRepository.transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { isolationLevel: 'Serializable' },
+    );
     expect(result.documentScope).toBe(ApplicationDocumentScope.APPLICATION);
     expect(result.version).toBe(2);
+  });
+
+  it('maps concurrent attach unique conflicts to ConflictException', async () => {
+    applicationsRepository.transaction.mockRejectedValue({ code: 'P2002' });
+
+    await expect(
+      service.attachDocument(
+        'application-1',
+        {
+          id: 'user-1',
+          email: 'lead@example.com',
+          role: UserRole.STUDENT,
+        } as never,
+        { fileId: 'file-1', documentType: DocumentType.BUDGET },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 
   it('rejects CV attachment without memberUserId', async () => {

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -1,24 +1,51 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { UserRole } from '../../generated/prisma/enums';
+import {
+  ApplicationDocumentScope,
+  ApplicationStatus,
+  DocumentType,
+  ProgramType,
+  UploadStatus,
+  UserRole,
+} from '../../generated/prisma/enums';
 import type { AuthenticatedUserContext } from '../common/types/auth-user-context.type';
+import { FilesRepository } from '../files/files.repository';
+import { TeamRepository } from '../team/team.repository';
+import { ApplicationDocumentsRepository } from './application-documents.repository';
+import { ApplicationRulesService } from './application-rules.service';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
+import { ApplicationDocumentDto } from './dto/application-document.dto';
+import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
+import { DocumentCompletenessDto } from './dto/document-completeness.dto';
+import { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';
 import {
   ApplicationWithRelations,
   ApplicationsRepository,
+  ApplicationWorkflowView,
 } from './applications.repository';
-import { ApplicationRulesService } from './application-rules.service';
+import { CallsRepository } from './calls.repository';
+
+type RequiredDocumentSlot = {
+  documentType: DocumentType;
+  documentScope: ApplicationDocumentScope;
+  memberUserId: string | null;
+};
 
 @Injectable()
 export class ApplicationsService {
   constructor(
     private readonly applicationsRepository: ApplicationsRepository,
+    private readonly applicationDocumentsRepository: ApplicationDocumentsRepository,
     private readonly applicationRulesService: ApplicationRulesService,
+    private readonly callsRepository: CallsRepository,
+    private readonly teamRepository: TeamRepository,
+    private readonly filesRepository: FilesRepository,
   ) {}
 
   async createDraft(
@@ -28,7 +55,6 @@ export class ApplicationsService {
     let created: ApplicationWithRelations;
 
     try {
-      // Use one transaction to prevent race conditions across validation, duplicate check, and create.
       created = await this.applicationsRepository.transaction(async (db) => {
         await this.applicationRulesService.validateApplicationCreationRules(
           dto.callId,
@@ -37,7 +63,6 @@ export class ApplicationsService {
           db,
         );
 
-        // Double-check inside transaction for active duplicate
         const existing =
           await this.applicationsRepository.findActiveByTeamAndCall(
             dto.teamId,
@@ -86,16 +111,364 @@ export class ApplicationsService {
     return this.toDetailDto(application);
   }
 
+  async getRequiredDocumentsForCall(
+    callId: string,
+  ): Promise<RequiredDocumentsResponseDto> {
+    const call =
+      await this.callsRepository.findByIdWithRequiredDocumentTypes(callId);
+
+    if (!call) {
+      throw new NotFoundException('Call not found');
+    }
+
+    return {
+      callId: call.id,
+      programType: call.type,
+      requiredDocuments:
+        call.type === ProgramType.PROGRAM_A
+          ? call.requiredDocumentTypes.map((document) => ({
+              id: document.id,
+              documentType: document.documentType,
+              isRequired: document.isRequired,
+            }))
+          : [],
+    };
+  }
+
+  async attachDocument(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+    dto: AttachApplicationDocumentDto,
+  ): Promise<ApplicationDocumentDto> {
+    const document = await this.applicationsRepository.transaction(
+      async (db) => {
+        const application = await this.loadWorkflowApplicationOrThrow(
+          applicationId,
+          db,
+        );
+
+        this.ensureProgramADocumentWorkflow(application);
+        this.ensureApplicationManagedByTeamLead(application, user.id);
+        this.ensureApplicationIsDraft(application);
+
+        const slot = this.resolveAttachmentSlot(application, dto);
+        const uploadedFile = await this.filesRepository.findByIdForOwners(
+          dto.fileId,
+          slot.allowedOwnerIds,
+          db,
+        );
+
+        if (!uploadedFile) {
+          throw new BadRequestException(
+            'File does not exist or cannot be attached to this application',
+          );
+        }
+
+        if (uploadedFile.status !== UploadStatus.UPLOADED) {
+          throw new BadRequestException(
+            'File must be uploaded before being attached to application documents',
+          );
+        }
+
+        await this.applicationDocumentsRepository.deactivateActiveBySlot(
+          application.id,
+          slot.documentType,
+          slot.documentScope,
+          slot.memberUserId,
+          db,
+        );
+
+        const latestVersion =
+          await this.applicationDocumentsRepository.findLatestVersionNumberBySlot(
+            application.id,
+            slot.documentType,
+            slot.documentScope,
+            slot.memberUserId,
+            db,
+          );
+
+        return this.applicationDocumentsRepository.createVersioned(
+          {
+            applicationId: application.id,
+            uploadedFileId: uploadedFile.id,
+            documentType: slot.documentType,
+            documentScope: slot.documentScope,
+            memberUserId: slot.memberUserId,
+            version: (latestVersion?.version ?? 0) + 1,
+            isActive: true,
+            createdById: user.id,
+          },
+          db,
+        );
+      },
+    );
+
+    return this.toApplicationDocumentDto(document);
+  }
+
+  async getDocumentCompleteness(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+  ): Promise<DocumentCompletenessDto> {
+    const application =
+      await this.loadWorkflowApplicationOrThrow(applicationId);
+
+    this.validateApplicationAccess(application, user);
+
+    return this.buildDocumentCompleteness(application);
+  }
+
+  async submit(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+  ): Promise<ApplicationDetailDto> {
+    const submitted = await this.applicationsRepository.transaction(
+      async (db) => {
+        const application = await this.loadWorkflowApplicationOrThrow(
+          applicationId,
+          db,
+        );
+
+        this.ensureApplicationManagedByTeamLead(application, user.id);
+        this.ensureApplicationIsDraft(application);
+        this.ensureApplicationCanBeSubmitted(application);
+
+        if (application.call.type === ProgramType.PROGRAM_A) {
+          const completeness = this.buildDocumentCompleteness(application);
+
+          if (!completeness.isComplete) {
+            throw new ConflictException(
+              'Application is missing required documents',
+            );
+          }
+        }
+
+        const now = new Date();
+        await this.applicationsRepository.submitDraft(application.id, now, db);
+
+        if (application.team.lockedAt === null) {
+          await this.teamRepository.update(
+            { id: application.team.id },
+            { lockedAt: now },
+            db,
+          );
+        }
+
+        const refreshed =
+          await this.applicationsRepository.findByIdWithRelations(
+            application.id,
+            db,
+          );
+
+        if (!refreshed) {
+          throw new NotFoundException('Application not found');
+        }
+
+        return refreshed;
+      },
+    );
+
+    return this.toDetailDto(submitted);
+  }
+
+  private async loadWorkflowApplicationOrThrow(
+    applicationId: string,
+    db?: Parameters<ApplicationsRepository['findByIdForWorkflow']>[1],
+  ): Promise<ApplicationWorkflowView> {
+    const application = await this.applicationsRepository.findByIdForWorkflow(
+      applicationId,
+      db,
+    );
+
+    if (!application) {
+      throw new NotFoundException('Application not found');
+    }
+
+    return application;
+  }
+
+  private ensureProgramADocumentWorkflow(application: ApplicationWorkflowView) {
+    if (application.call.type !== ProgramType.PROGRAM_A) {
+      throw new ConflictException(
+        'Application document pack is supported only for Program A applications',
+      );
+    }
+  }
+
+  private ensureApplicationManagedByTeamLead(
+    application: ApplicationWorkflowView,
+    userId: string,
+  ): void {
+    if (application.team.leaderId !== userId) {
+      throw new ForbiddenException(
+        'Only team lead can manage application documents and submission',
+      );
+    }
+  }
+
+  private ensureApplicationIsDraft(application: ApplicationWorkflowView): void {
+    if (application.status !== ApplicationStatus.DRAFT) {
+      throw new ConflictException(
+        `Only draft applications can be submitted (status: ${application.status})`,
+      );
+    }
+  }
+
+  private ensureApplicationCanBeSubmitted(
+    application: ApplicationWorkflowView,
+  ): void {
+    if (application.team.archivedAt !== null) {
+      throw new ConflictException(
+        'Team is archived and cannot submit applications',
+      );
+    }
+
+    this.applicationRulesService.ensureCallOpenForApplications(
+      application.call,
+    );
+  }
+
+  private resolveAttachmentSlot(
+    application: ApplicationWorkflowView,
+    dto: AttachApplicationDocumentDto,
+  ): RequiredDocumentSlot & { allowedOwnerIds: string[] } {
+    if (dto.documentType === DocumentType.CV) {
+      if (!dto.memberUserId) {
+        throw new BadRequestException(
+          'memberUserId is required for CV attachments',
+        );
+      }
+
+      const isTeamMember = application.team.members.some(
+        (member) => member.userId === dto.memberUserId,
+      );
+
+      if (!isTeamMember) {
+        throw new BadRequestException(
+          'CV can only be attached for a current team member',
+        );
+      }
+
+      return {
+        documentType: dto.documentType,
+        documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+        memberUserId: dto.memberUserId,
+        allowedOwnerIds: [
+          ...new Set([application.team.leaderId, dto.memberUserId]),
+        ],
+      };
+    }
+
+    if (dto.memberUserId) {
+      throw new BadRequestException(
+        'memberUserId is only allowed for CV attachments',
+      );
+    }
+
+    return {
+      documentType: dto.documentType,
+      documentScope: ApplicationDocumentScope.APPLICATION,
+      memberUserId: null,
+      allowedOwnerIds: [application.team.leaderId],
+    };
+  }
+
+  private buildDocumentCompleteness(
+    application: ApplicationWorkflowView,
+  ): DocumentCompletenessDto {
+    if (application.call.type !== ProgramType.PROGRAM_A) {
+      return {
+        applicationId: application.id,
+        isComplete: true,
+        satisfiedDocuments: [],
+        missingDocuments: [],
+      };
+    }
+
+    const requiredSlots = this.buildRequiredDocumentSlots(application);
+    const activeDocumentKeys = new Set(
+      application.documents.map((document) =>
+        this.buildDocumentSlotKey(
+          document.documentType,
+          document.documentScope,
+          document.memberUserId,
+        ),
+      ),
+    );
+
+    const satisfiedDocuments = requiredSlots.filter((slot) =>
+      activeDocumentKeys.has(
+        this.buildDocumentSlotKey(
+          slot.documentType,
+          slot.documentScope,
+          slot.memberUserId,
+        ),
+      ),
+    );
+
+    const missingDocuments = requiredSlots.filter(
+      (slot) =>
+        !activeDocumentKeys.has(
+          this.buildDocumentSlotKey(
+            slot.documentType,
+            slot.documentScope,
+            slot.memberUserId,
+          ),
+        ),
+    );
+
+    return {
+      applicationId: application.id,
+      isComplete: missingDocuments.length === 0,
+      satisfiedDocuments,
+      missingDocuments,
+    };
+  }
+
+  private buildRequiredDocumentSlots(
+    application: ApplicationWorkflowView,
+  ): RequiredDocumentSlot[] {
+    const slots: RequiredDocumentSlot[] = [];
+
+    for (const requiredDocument of application.call.requiredDocumentTypes) {
+      if (requiredDocument.documentType === DocumentType.CV) {
+        for (const member of application.team.members) {
+          slots.push({
+            documentType: DocumentType.CV,
+            documentScope: ApplicationDocumentScope.TEAM_MEMBER,
+            memberUserId: member.userId,
+          });
+        }
+
+        continue;
+      }
+
+      slots.push({
+        documentType: requiredDocument.documentType,
+        documentScope: ApplicationDocumentScope.APPLICATION,
+        memberUserId: null,
+      });
+    }
+
+    return slots;
+  }
+
+  private buildDocumentSlotKey(
+    documentType: DocumentType,
+    documentScope: ApplicationDocumentScope,
+    memberUserId: string | null,
+  ): string {
+    return `${documentType}:${documentScope}:${memberUserId ?? 'application'}`;
+  }
+
   private validateApplicationAccess(
-    application: ApplicationWithRelations,
+    application: ApplicationWithRelations | ApplicationWorkflowView,
     user: AuthenticatedUserContext,
   ): void {
-    // Admins can always view applications
     if (user.role === UserRole.ADMIN || user.role === UserRole.SUPER_ADMIN) {
       return;
     }
 
-    // Team members (including lead) can view their team's applications
     const isTeamMember =
       application.team.leaderId === user.id ||
       application.team.members?.some((member) => member.userId === user.id);
@@ -120,6 +493,30 @@ export class ApplicationsService {
       decidedAt: application.decidedAt,
       createdAt: application.createdAt,
       updatedAt: application.updatedAt,
+    };
+  }
+
+  private toApplicationDocumentDto(
+    document: Awaited<
+      ReturnType<ApplicationDocumentsRepository['createVersioned']>
+    >,
+  ): ApplicationDocumentDto {
+    return {
+      id: document.id,
+      applicationId: document.applicationId,
+      documentType: document.documentType,
+      documentScope: document.documentScope,
+      memberUserId: document.memberUserId,
+      uploadedFileId: document.uploadedFileId,
+      version: document.version,
+      isActive: document.isActive,
+      originalName: document.uploadedFile.originalName,
+      mimeType: document.uploadedFile.mimeType,
+      size: document.uploadedFile.size,
+      visibility: document.uploadedFile.visibility,
+      uploadStatus: document.uploadedFile.status,
+      uploadedFileOwnerId: document.uploadedFile.ownerId,
+      createdAt: document.createdAt,
     };
   }
 

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '../../generated/prisma/client';
 import {
   ApplicationDocumentScope,
   ApplicationStatus,
@@ -40,7 +41,7 @@ type RequiredDocumentSlot = {
 @Injectable()
 export class ApplicationsService {
   private readonly applicationDocumentAttachTransactionOptions = {
-    isolationLevel: 'Serializable' as const,
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
   } as const;
 
   constructor(

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -39,6 +39,10 @@ type RequiredDocumentSlot = {
 
 @Injectable()
 export class ApplicationsService {
+  private readonly applicationDocumentAttachTransactionOptions = {
+    isolationLevel: 'Serializable' as const,
+  } as const;
+
   constructor(
     private readonly applicationsRepository: ApplicationsRepository,
     private readonly applicationDocumentsRepository: ApplicationDocumentsRepository,
@@ -140,8 +144,12 @@ export class ApplicationsService {
     user: AuthenticatedUserContext,
     dto: AttachApplicationDocumentDto,
   ): Promise<ApplicationDocumentDto> {
-    const document = await this.applicationsRepository.transaction(
-      async (db) => {
+    let document: Awaited<
+      ReturnType<ApplicationDocumentsRepository['createVersioned']>
+    >;
+
+    try {
+      document = await this.applicationsRepository.transaction(async (db) => {
         const application = await this.loadWorkflowApplicationOrThrow(
           applicationId,
           db,
@@ -200,8 +208,16 @@ export class ApplicationsService {
           },
           db,
         );
-      },
-    );
+      }, this.applicationDocumentAttachTransactionOptions);
+    } catch (error) {
+      if (this.isUniqueConstraintError(error)) {
+        throw new ConflictException(
+          'Another document was attached to this slot concurrently. Please retry.',
+        );
+      }
+
+      throw error;
+    }
 
     return this.toApplicationDocumentDto(document);
   }
@@ -309,7 +325,7 @@ export class ApplicationsService {
   private ensureApplicationIsDraft(application: ApplicationWorkflowView): void {
     if (application.status !== ApplicationStatus.DRAFT) {
       throw new ConflictException(
-        `Only draft applications can be submitted (status: ${application.status})`,
+        `Only draft applications can be modified or submitted (status: ${application.status})`,
       );
     }
   }

--- a/src/applications/calls-documents.controller.spec.ts
+++ b/src/applications/calls-documents.controller.spec.ts
@@ -1,0 +1,31 @@
+jest.mock('./applications.service', () => ({
+  ApplicationsService: class ApplicationsService {},
+}));
+
+jest.mock('../auth/guards/jwt-auth.guard', () => ({
+  JwtAuthGuard: class JwtAuthGuard {},
+}));
+
+import { CallsDocumentsController } from './calls-documents.controller';
+import { ApplicationsService } from './applications.service';
+
+describe('CallsDocumentsController', () => {
+  it('delegates required document lookup to the applications service', async () => {
+    const applicationsService = {
+      getRequiredDocumentsForCall: jest
+        .fn()
+        .mockResolvedValue({ callId: 'call-1' }),
+    };
+
+    const controller = new CallsDocumentsController(
+      applicationsService as unknown as ApplicationsService,
+    );
+
+    await expect(controller.getRequiredDocuments('call-1')).resolves.toEqual({
+      callId: 'call-1',
+    });
+    expect(
+      applicationsService.getRequiredDocumentsForCall,
+    ).toHaveBeenCalledWith('call-1');
+  });
+});

--- a/src/applications/calls-documents.controller.ts
+++ b/src/applications/calls-documents.controller.ts
@@ -1,0 +1,27 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetRequiredDocumentsApi } from './api-docs';
+import { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';
+import { ApplicationsService } from './applications.service';
+
+@ApiTags('Calls')
+@UseGuards(JwtAuthGuard)
+@Controller('calls')
+export class CallsDocumentsController {
+  constructor(private readonly applicationsService: ApplicationsService) {}
+
+  @GetRequiredDocumentsApi()
+  @Get(':callId/required-documents')
+  getRequiredDocuments(
+    @Param('callId', ParseUUIDPipe) callId: string,
+  ): Promise<RequiredDocumentsResponseDto> {
+    return this.applicationsService.getRequiredDocumentsForCall(callId);
+  }
+}

--- a/src/applications/calls.repository.ts
+++ b/src/applications/calls.repository.ts
@@ -3,6 +3,10 @@ import type { Call, Prisma } from '../../generated/prisma/client';
 import { BaseRepository, PrismaDbClient } from '../infrastructure/database';
 import { PrismaService } from '../infrastructure/database/prisma.service';
 
+export type CallWithRequiredDocumentTypes = Prisma.CallGetPayload<{
+  select: ReturnType<CallsRepository['requiredDocumentTypesSelect']>;
+}>;
+
 @Injectable()
 export class CallsRepository extends BaseRepository<
   Call,
@@ -24,5 +28,36 @@ export class CallsRepository extends BaseRepository<
     return (db ?? this.prisma.client).call.findUnique({
       where: { id },
     });
+  }
+
+  findByIdWithRequiredDocumentTypes(
+    id: string,
+    db?: PrismaDbClient,
+  ): Promise<CallWithRequiredDocumentTypes | null> {
+    return (db ?? this.prisma.client).call.findUnique({
+      where: { id },
+      select: this.requiredDocumentTypesSelect(),
+    });
+  }
+
+  private requiredDocumentTypesSelect() {
+    return {
+      id: true,
+      type: true,
+      title: true,
+      requiredDocumentTypes: {
+        where: {
+          isRequired: true,
+        },
+        select: {
+          id: true,
+          documentType: true,
+          isRequired: true,
+        },
+        orderBy: {
+          documentType: 'asc',
+        },
+      },
+    } as const;
   }
 }

--- a/src/applications/dto/application-document.dto.ts
+++ b/src/applications/dto/application-document.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ApplicationDocumentScope,
+  DocumentType,
+  FileVisibility,
+  UploadStatus,
+} from '../../../generated/prisma/enums';
+
+export class ApplicationDocumentDto {
+  @ApiProperty({ example: 'f6c90688-c973-40ca-8f3b-c55667cc6f77' })
+  id!: string;
+
+  @ApiProperty({ example: '87dcb0e9-2f7e-4ab5-b014-d2f1204bc138' })
+  applicationId!: string;
+
+  @ApiProperty({ enum: DocumentType })
+  documentType!: DocumentType;
+
+  @ApiProperty({ enum: ApplicationDocumentScope })
+  documentScope!: ApplicationDocumentScope;
+
+  @ApiPropertyOptional({ example: 'b91e88db-5d96-443d-956b-ac4fdcbf95f7' })
+  memberUserId!: string | null;
+
+  @ApiProperty({ example: 'd8d89d76-1a4c-4cc8-b804-e7fcf58567af' })
+  uploadedFileId!: string;
+
+  @ApiProperty({ example: 2 })
+  version!: number;
+
+  @ApiProperty({ example: true })
+  isActive!: boolean;
+
+  @ApiProperty({ example: 'budget.pdf' })
+  originalName!: string;
+
+  @ApiProperty({ example: 'application/pdf' })
+  mimeType!: string;
+
+  @ApiProperty({ example: 124991 })
+  size!: number;
+
+  @ApiProperty({ enum: FileVisibility })
+  visibility!: FileVisibility;
+
+  @ApiProperty({ enum: UploadStatus })
+  uploadStatus!: UploadStatus;
+
+  @ApiProperty({ example: 'user-1' })
+  uploadedFileOwnerId!: string;
+
+  @ApiProperty({ example: '2026-05-02T08:00:00.000Z' })
+  createdAt!: Date;
+}

--- a/src/applications/dto/application-document.dto.ts
+++ b/src/applications/dto/application-document.dto.ts
@@ -19,7 +19,10 @@ export class ApplicationDocumentDto {
   @ApiProperty({ enum: ApplicationDocumentScope })
   documentScope!: ApplicationDocumentScope;
 
-  @ApiPropertyOptional({ example: 'b91e88db-5d96-443d-956b-ac4fdcbf95f7' })
+  @ApiPropertyOptional({
+    example: 'b91e88db-5d96-443d-956b-ac4fdcbf95f7',
+    nullable: true,
+  })
   memberUserId!: string | null;
 
   @ApiProperty({ example: 'd8d89d76-1a4c-4cc8-b804-e7fcf58567af' })

--- a/src/applications/dto/attach-application-document.dto.ts
+++ b/src/applications/dto/attach-application-document.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { DocumentType } from '../../../generated/prisma/enums';
+
+export class AttachApplicationDocumentDto {
+  @ApiProperty({
+    description: 'Previously uploaded file identifier.',
+    example: 'd8d89d76-1a4c-4cc8-b804-e7fcf58567af',
+  })
+  @IsUUID()
+  fileId!: string;
+
+  @ApiProperty({ enum: DocumentType })
+  @IsEnum(DocumentType)
+  documentType!: DocumentType;
+
+  @ApiPropertyOptional({
+    description:
+      'Required only for member-scoped CV attachments. Identifies the team member whose CV is being attached.',
+    example: 'b91e88db-5d96-443d-956b-ac4fdcbf95f7',
+  })
+  @IsOptional()
+  @IsUUID()
+  memberUserId?: string;
+}

--- a/src/applications/dto/document-completeness-item.dto.ts
+++ b/src/applications/dto/document-completeness-item.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ApplicationDocumentScope,
+  DocumentType,
+} from '../../../generated/prisma/enums';
+
+export class DocumentCompletenessItemDto {
+  @ApiProperty({ enum: DocumentType })
+  documentType!: DocumentType;
+
+  @ApiProperty({ enum: ApplicationDocumentScope })
+  documentScope!: ApplicationDocumentScope;
+
+  @ApiPropertyOptional({ example: 'user-2' })
+  memberUserId!: string | null;
+}

--- a/src/applications/dto/document-completeness-item.dto.ts
+++ b/src/applications/dto/document-completeness-item.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   ApplicationDocumentScope,
   DocumentType,
@@ -11,6 +11,6 @@ export class DocumentCompletenessItemDto {
   @ApiProperty({ enum: ApplicationDocumentScope })
   documentScope!: ApplicationDocumentScope;
 
-  @ApiPropertyOptional({ example: 'user-2', nullable: true })
+  @ApiProperty({ example: 'user-2', nullable: true })
   memberUserId!: string | null;
 }

--- a/src/applications/dto/document-completeness-item.dto.ts
+++ b/src/applications/dto/document-completeness-item.dto.ts
@@ -11,6 +11,6 @@ export class DocumentCompletenessItemDto {
   @ApiProperty({ enum: ApplicationDocumentScope })
   documentScope!: ApplicationDocumentScope;
 
-  @ApiPropertyOptional({ example: 'user-2' })
+  @ApiPropertyOptional({ example: 'user-2', nullable: true })
   memberUserId!: string | null;
 }

--- a/src/applications/dto/document-completeness.dto.ts
+++ b/src/applications/dto/document-completeness.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DocumentCompletenessItemDto } from './document-completeness-item.dto';
+
+export class DocumentCompletenessDto {
+  @ApiProperty({ example: 'application-1' })
+  applicationId!: string;
+
+  @ApiProperty({ example: true })
+  isComplete!: boolean;
+
+  @ApiProperty({ type: [DocumentCompletenessItemDto] })
+  satisfiedDocuments!: DocumentCompletenessItemDto[];
+
+  @ApiProperty({ type: [DocumentCompletenessItemDto] })
+  missingDocuments!: DocumentCompletenessItemDto[];
+}

--- a/src/applications/dto/required-document-type.dto.ts
+++ b/src/applications/dto/required-document-type.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DocumentType } from '../../../generated/prisma/enums';
+
+export class RequiredDocumentTypeDto {
+  @ApiProperty({ example: 'e7167d41-c4af-4f71-a6e6-bba77f6bb646' })
+  id!: string;
+
+  @ApiProperty({ enum: DocumentType })
+  documentType!: DocumentType;
+
+  @ApiProperty({ example: true })
+  isRequired!: boolean;
+}

--- a/src/applications/dto/required-documents-response.dto.ts
+++ b/src/applications/dto/required-documents-response.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ProgramType } from '../../../generated/prisma/enums';
+import { RequiredDocumentTypeDto } from './required-document-type.dto';
+
+export class RequiredDocumentsResponseDto {
+  @ApiProperty({ example: '87dcb0e9-2f7e-4ab5-b014-d2f1204bc138' })
+  callId!: string;
+
+  @ApiProperty({ enum: ProgramType })
+  programType!: ProgramType;
+
+  @ApiProperty({ type: [RequiredDocumentTypeDto] })
+  requiredDocuments!: RequiredDocumentTypeDto[];
+}

--- a/src/applications/index.ts
+++ b/src/applications/index.ts
@@ -1,9 +1,24 @@
 export { ApplicationsModule } from './applications.module';
 export { ApplicationsService } from './applications.service';
 export { ApplicationsRepository } from './applications.repository';
+export { ApplicationDocumentsRepository } from './application-documents.repository';
 export { ApplicationsController } from './applications.controller';
+export { CallsDocumentsController } from './calls-documents.controller';
 export { ApplicationRulesService } from './application-rules.service';
 export { CallsRepository } from './calls.repository';
-export { CreateApplicationApi, GetApplicationApi } from './api-docs';
+export {
+  AttachApplicationDocumentApi,
+  CreateApplicationApi,
+  GetApplicationApi,
+  GetApplicationDocumentCompletenessApi,
+  GetRequiredDocumentsApi,
+  SubmitApplicationApi,
+} from './api-docs';
 export { ApplicationDetailDto } from './dto/application-detail.dto';
+export { ApplicationDocumentDto } from './dto/application-document.dto';
+export { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 export { CreateApplicationDto } from './dto/create-application.dto';
+export { DocumentCompletenessDto } from './dto/document-completeness.dto';
+export { DocumentCompletenessItemDto } from './dto/document-completeness-item.dto';
+export { RequiredDocumentTypeDto } from './dto/required-document-type.dto';
+export { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -9,6 +9,6 @@ import { FilesService } from './files.service';
   imports: [AuthModule, StorageModule],
   controllers: [FilesController],
   providers: [FilesRepository, FilesService],
-  exports: [FilesService],
+  exports: [FilesRepository, FilesService],
 })
 export class FilesModule {}

--- a/src/files/files.repository.ts
+++ b/src/files/files.repository.ts
@@ -41,6 +41,22 @@ export class FilesRepository extends BaseRepository<
     );
   }
 
+  findByIdForOwners(
+    id: string,
+    ownerIds: string[],
+    db?: PrismaDbClient,
+  ): Promise<UploadedFile | null> {
+    return this.findFirst(
+      {
+        id,
+        ownerId: {
+          in: ownerIds,
+        },
+      },
+      db,
+    );
+  }
+
   markUploaded(
     id: string,
     uploadedAt = new Date(),


### PR DESCRIPTION
Summary
  Implemented Program A application document management: required document configuration per call,
  document attachment with versioning, completeness checks, and submission validation.

  Changes

  - Added RequiredDocumentType and ApplicationDocument data models with Prisma migration and schema
    updates.
  - Seeded Program A calls with required document types.
  - Added endpoints for:
      - creating applications
      - attaching application documents
      - checking document completeness
      - fetching required documents for a call
      - submitting applications
  - Added business rules for:
      - team-lead-only document management and submission
      - CV attachments scoped to team members
      - file ownership and upload-status validation
      - Program A submission blocked until all required documents are attached
      - team locking after submission
  - Added new repositories, DTOs, Swagger docs, and tests for the workflow.

  Notes

  - Program B calls return no required documents.
  - Document attachments are versioned; previous active documents for the same slot are deactivated.