### PR TITLE
feat: add organization member lifecycle api

### DIFF
--- a/src/organization/api-docs/index.ts
+++ b/src/organization/api-docs/index.ts
@@ -3,7 +3,11 @@ export {
   CreateOrganizationInviteApi,
   GetMyOrganizationApi,
   GetOrganizationInvitesApi,
+  ListOrganizationMembersApi,
+  RemoveOrganizationMemberApi,
   ResendOrganizationInviteApi,
   RevokeOrganizationInviteApi,
+  TransferOrganizationOwnerApi,
   UpdateMyOrganizationApi,
+  UpdateOrganizationMemberRoleApi,
 } from './organization-api-docs.decorators';

--- a/src/organization/api-docs/organization-api-docs.decorators.ts
+++ b/src/organization/api-docs/organization-api-docs.decorators.ts
@@ -18,6 +18,9 @@ import { OrganizationResponseDto } from '../dto/organization-response.dto';
 import { ResendOrganizationInviteResponseDto } from '../dto/resend-organization-invite-response.dto';
 import { RevokeOrganizationInviteResponseDto } from '../dto/revoke-organization-invite-response.dto';
 import { UpdateOrganizationProfileDto } from '../dto/update-organization-profile.dto';
+import { OrganizationMemberResponseDto } from '../dto/organization-member-response.dto';
+import { TransferOrganizationOwnerDto } from '../dto/transfer-organization-owner.dto';
+import { UpdateOrganizationMemberRoleDto } from '../dto/update-organization-member-role.dto';
 
 export const CreateOrganizationApi = () =>
   createApiDecorator({
@@ -287,6 +290,162 @@ export const ResendOrganizationInviteApi = () =>
       }),
       ApiNotFoundResponse({
         description: 'Organization or invitation not found.',
+      }),
+    ],
+  });
+
+export const ListOrganizationMembersApi = () =>
+  createApiDecorator({
+    summary: 'List organization members',
+    description:
+      'Returns users linked to the organization. Company owners and company employees can list members only inside their own organization.',
+    successResponse: {
+      status: 200,
+      type: OrganizationMemberResponseDto,
+      description: 'Organization members were retrieved successfully.',
+      isArray: true,
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ApiParam({
+        name: 'id',
+        description: 'Organization identifier.',
+        format: 'uuid',
+      }),
+    ],
+    errors: [
+      ApiBadRequestResponse({
+        description: 'Organization identifier is malformed.',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'The authenticated user is not allowed to list members of this organization.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Organization not found.',
+      }),
+    ],
+  });
+
+export const UpdateOrganizationMemberRoleApi = () =>
+  createApiDecorator({
+    summary: 'Update organization member role',
+    description:
+      'Updates the role of a non-owner organization member. Ownership transfer must be done through the dedicated owner transfer endpoint.',
+    body: UpdateOrganizationMemberRoleDto,
+    successResponse: {
+      status: 200,
+      type: OrganizationMemberResponseDto,
+      description: 'Organization member role was updated successfully.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ApiParam({
+        name: 'id',
+        description: 'Organization identifier.',
+        format: 'uuid',
+      }),
+      ApiParam({
+        name: 'userId',
+        description: 'Organization member user identifier.',
+        format: 'uuid',
+      }),
+    ],
+    errors: [
+      ApiBadRequestResponse({
+        description:
+          'Organization or user identifier is malformed, request body is invalid, or role change is not allowed.',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'Only the current company owner of this organization may update member roles.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Organization or member not found.',
+      }),
+    ],
+  });
+
+export const RemoveOrganizationMemberApi = () =>
+  createApiDecorator({
+    summary: 'Remove organization member',
+    description:
+      'Removes a non-owner member from the organization. The current company owner cannot be removed directly.',
+    successResponse: {
+      status: 200,
+      type: OrganizationMemberResponseDto,
+      description: 'Organization member was removed successfully.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ApiParam({
+        name: 'id',
+        description: 'Organization identifier.',
+        format: 'uuid',
+      }),
+      ApiParam({
+        name: 'userId',
+        description: 'Organization member user identifier.',
+        format: 'uuid',
+      }),
+    ],
+    errors: [
+      ApiBadRequestResponse({
+        description:
+          'Organization or user identifier is malformed, or the current owner removal was attempted.',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'Only the current company owner of this organization may remove members.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Organization or member not found.',
+      }),
+    ],
+  });
+
+export const TransferOrganizationOwnerApi = () =>
+  createApiDecorator({
+    summary: 'Transfer organization ownership',
+    description:
+      'Transfers organization ownership to another active member in the same organization. The old owner is demoted to company employee and the new owner becomes company owner in one transaction.',
+    body: TransferOrganizationOwnerDto,
+    successResponse: {
+      status: 200,
+      type: OrganizationMemberResponseDto,
+      description: 'Organization ownership was transferred successfully.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ApiParam({
+        name: 'id',
+        description: 'Organization identifier.',
+        format: 'uuid',
+      }),
+    ],
+    errors: [
+      ApiBadRequestResponse({
+        description:
+          'Organization identifier is malformed, new owner is already the current owner, or new owner is not active.',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'Only the current company owner of this organization may transfer ownership.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Organization or new owner member not found.',
       }),
     ],
   });

--- a/src/organization/dto/organization-member-response.dto.ts
+++ b/src/organization/dto/organization-member-response.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { UserRole, UserStatus } from '../../../generated/prisma/enums';
-
+import { UserRole, UserStatus } from 'generated/prisma/enums';
 export class OrganizationMemberResponseDto {
   @ApiProperty({
     description: 'User identifier.',

--- a/src/organization/dto/organization-member-response.dto.ts
+++ b/src/organization/dto/organization-member-response.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole, UserStatus } from '../../../generated/prisma/enums';
+
+export class OrganizationMemberResponseDto {
+  @ApiProperty({
+    description: 'User identifier.',
+    format: 'uuid',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Member first name.',
+  })
+  firstName!: string;
+
+  @ApiProperty({
+    description: 'Member last name.',
+  })
+  lastName!: string;
+
+  @ApiProperty({
+    description: 'Member email.',
+    format: 'email',
+  })
+  email!: string;
+
+  @ApiProperty({
+    description: 'Member role in organization.',
+    enum: UserRole,
+  })
+  role!: UserRole;
+
+  @ApiProperty({
+    description: 'Member account status.',
+    enum: UserStatus,
+  })
+  status!: UserStatus;
+
+  @ApiPropertyOptional({
+    description: 'Organization id.',
+    format: 'uuid',
+    nullable: true,
+  })
+  organizationId!: string | null;
+
+  @ApiProperty({
+    description: 'When user was created.',
+    type: String,
+    format: 'date-time',
+  })
+  createdAt!: Date;
+
+  @ApiProperty({
+    description: 'When user was last updated.',
+    type: String,
+    format: 'date-time',
+  })
+  updatedAt!: Date;
+}

--- a/src/organization/dto/transfer-organization-owner.dto.ts
+++ b/src/organization/dto/transfer-organization-owner.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class TransferOrganizationOwnerDto {
+  @ApiProperty({
+    description:
+      'User id of the member who should become the new organization owner.',
+    format: 'uuid',
+    example: 'd5af8ff2-69e9-4f31-bd0b-a2a226c9ffc5',
+  })
+  @IsUUID()
+  newOwnerUserId!: string;
+}

--- a/src/organization/dto/update-organization-member-role.dto.ts
+++ b/src/organization/dto/update-organization-member-role.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { UserRole } from '../../../generated/prisma/enums';
+
+export const ORGANIZATION_MEMBER_ROLES = {
+  COMPANY_EMPLOYEE: UserRole.COMPANY_EMPLOYEE,
+  COMPANY_OWNER: UserRole.COMPANY_OWNER,
+} as const;
+
+export type OrganizationMemberRole =
+  (typeof ORGANIZATION_MEMBER_ROLES)[keyof typeof ORGANIZATION_MEMBER_ROLES];
+
+export class UpdateOrganizationMemberRoleDto {
+  @ApiProperty({
+    description: 'New organization member role.',
+    enum: ORGANIZATION_MEMBER_ROLES,
+    enumName: 'OrganizationMemberRole',
+    example: ORGANIZATION_MEMBER_ROLES.COMPANY_EMPLOYEE,
+  })
+  @IsEnum(ORGANIZATION_MEMBER_ROLES)
+  role!: OrganizationMemberRole;
+}

--- a/src/organization/dto/update-organization-member-role.dto.ts
+++ b/src/organization/dto/update-organization-member-role.dto.ts
@@ -1,10 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
-import { UserRole } from '../../../generated/prisma/enums';
+import { UserRole } from 'generated/prisma/enums';
 
 export const ORGANIZATION_MEMBER_ROLES = {
   COMPANY_EMPLOYEE: UserRole.COMPANY_EMPLOYEE,
-  COMPANY_OWNER: UserRole.COMPANY_OWNER,
 } as const;
 
 export type OrganizationMemberRole =

--- a/src/organization/organization.controller.ts
+++ b/src/organization/organization.controller.ts
@@ -23,9 +23,13 @@ import {
   CreateOrganizationInviteApi,
   GetMyOrganizationApi,
   GetOrganizationInvitesApi,
+  ListOrganizationMembersApi,
+  RemoveOrganizationMemberApi,
   ResendOrganizationInviteApi,
   RevokeOrganizationInviteApi,
+  TransferOrganizationOwnerApi,
   UpdateMyOrganizationApi,
+  UpdateOrganizationMemberRoleApi,
 } from './api-docs';
 import { CreateOrganizationInviteDto } from './dto/create-organization-invite.dto';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
@@ -36,6 +40,9 @@ import { OrganizationResponseDto } from './dto/organization-response.dto';
 import { ResendOrganizationInviteResponseDto } from './dto/resend-organization-invite-response.dto';
 import { RevokeOrganizationInviteResponseDto } from './dto/revoke-organization-invite-response.dto';
 import { UpdateOrganizationProfileDto } from './dto/update-organization-profile.dto';
+import { OrganizationMemberResponseDto } from './dto/organization-member-response.dto';
+import { TransferOrganizationOwnerDto } from './dto/transfer-organization-owner.dto';
+import { UpdateOrganizationMemberRoleDto } from './dto/update-organization-member-role.dto';
 
 @ApiTags('Organizations')
 @Controller('/organizations')
@@ -120,5 +127,53 @@ export class OrganizationController {
     @GetUserContext() user: AuthenticatedUserContext,
   ): Promise<ResendOrganizationInviteResponseDto> {
     return this.service.resendInvite(id, inviteId, user);
+  }
+
+  @Get(':id/members')
+  @ListOrganizationMembersApi()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE)
+  async listMembers(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<OrganizationMemberResponseDto[]> {
+    return this.service.listMembers(id, user);
+  }
+
+  @Patch(':id/members/:userId/role')
+  @UpdateOrganizationMemberRoleApi()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.COMPANY_OWNER)
+  async updateMemberRole(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Body() dto: UpdateOrganizationMemberRoleDto,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<OrganizationMemberResponseDto> {
+    return this.service.updateMemberRole(id, userId, dto, user);
+  }
+
+  @Delete(':id/members/:userId')
+  @RemoveOrganizationMemberApi()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.COMPANY_OWNER)
+  async removeMember(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<OrganizationMemberResponseDto> {
+    return this.service.removeMember(id, userId, user);
+  }
+
+  @Patch(':id/owner')
+  @TransferOrganizationOwnerApi()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.COMPANY_OWNER)
+  async transferOwner(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: TransferOrganizationOwnerDto,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<OrganizationMemberResponseDto> {
+    return this.service.transferOwner(id, dto, user);
   }
 }

--- a/src/organization/organization.service.spec.ts
+++ b/src/organization/organization.service.spec.ts
@@ -92,6 +92,7 @@ import { HashingService } from 'src/infrastructure/hashing';
 import { QueueService } from 'src/infrastructure/queue';
 import { UserRepository } from 'src/user/user.repository';
 import type { UpdateOrganizationProfileDto } from './dto/update-organization-profile.dto';
+import type { UpdateOrganizationMemberRoleDto } from './dto/update-organization-member-role.dto';
 import { OrganizationInviteRepository } from './organization-invitation.repository';
 import { OrganizationRepository } from './organization.repository';
 import { OrganizationService } from './organization.service';
@@ -541,13 +542,12 @@ describe('OrganizationService', () => {
 
       userRepository.findOrganizationMember.mockResolvedValue(employee);
 
+      const invalidDto = {
+        role: UserRole.COMPANY_OWNER,
+      } as unknown as UpdateOrganizationMemberRoleDto;
+
       await expect(
-        service.updateMemberRole(
-          'org-1',
-          'employee-1',
-          { role: UserRole.COMPANY_OWNER },
-          owner,
-        ),
+        service.updateMemberRole('org-1', 'employee-1', invalidDto, owner),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 

--- a/src/organization/organization.service.spec.ts
+++ b/src/organization/organization.service.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('../../generated/prisma/client', () => ({}), { virtual: true });
 jest.mock('@prisma/client', () => ({}), { virtual: true });
 jest.mock('generated/prisma/client', () => ({}), { virtual: true });
+
 jest.mock(
   'generated/prisma/enums',
   () => ({
@@ -17,11 +18,14 @@ jest.mock(
       SUSPENDED: 'SUSPENDED',
     },
     UserRole: {
+      STUDENT: 'STUDENT',
       COMPANY_OWNER: 'COMPANY_OWNER',
       COMPANY_EMPLOYEE: 'COMPANY_EMPLOYEE',
     },
     UserStatus: {
       ACTIVE: 'ACTIVE',
+      PENDING: 'PENDING',
+      SUSPENDED: 'SUSPENDED',
     },
   }),
   { virtual: true },
@@ -30,6 +34,7 @@ jest.mock(
 jest.mock('./organization.repository', () => ({
   OrganizationRepository: class OrganizationRepository {},
 }));
+
 jest.mock(
   'src/user/user.repository',
   () => ({
@@ -37,6 +42,7 @@ jest.mock(
   }),
   { virtual: true },
 );
+
 jest.mock(
   'src/infrastructure/queue',
   () => ({
@@ -48,9 +54,11 @@ jest.mock(
   }),
   { virtual: true },
 );
+
 jest.mock('./organization-invitation.repository', () => ({
   OrganizationInviteRepository: class OrganizationInviteRepository {},
 }));
+
 jest.mock(
   'src/infrastructure/hashing',
   () => ({
@@ -58,6 +66,7 @@ jest.mock(
   }),
   { virtual: true },
 );
+
 jest.mock(
   'src/infrastructure/config',
   () => ({
@@ -82,26 +91,35 @@ import { ConfigService } from 'src/infrastructure/config';
 import { HashingService } from 'src/infrastructure/hashing';
 import { QueueService } from 'src/infrastructure/queue';
 import { UserRepository } from 'src/user/user.repository';
+import type { UpdateOrganizationProfileDto } from './dto/update-organization-profile.dto';
 import { OrganizationInviteRepository } from './organization-invitation.repository';
 import { OrganizationRepository } from './organization.repository';
 import { OrganizationService } from './organization.service';
 
 describe('OrganizationService', () => {
   let service: OrganizationService;
+
   let organizationRepository: {
     findUnique: jest.Mock;
     transaction: jest.Mock;
     create: jest.Mock;
     update: jest.Mock;
   };
+
   let userRepository: {
     findByEmail: jest.Mock;
     findAdmins: jest.Mock;
     updateOrganizationIfNotExists: jest.Mock;
+    findOrganizationMembers: jest.Mock;
+    findOrganizationMember: jest.Mock;
+    updateUserRole: jest.Mock;
+    update: jest.Mock;
   };
+
   let queueService: {
     addEmail: jest.Mock;
   };
+
   let organizationInviteRepository: {
     findActivePendingByEmailAndOrganization: jest.Mock;
     findByIdAndOrganization: jest.Mock;
@@ -111,9 +129,11 @@ describe('OrganizationService', () => {
     update: jest.Mock;
     delete: jest.Mock;
   };
+
   let hashingService: {
     generateHexToken: jest.Mock;
   };
+
   let configService: {
     tokenByteLength: number;
     organizationInvitationExpirationDays: number;
@@ -123,6 +143,14 @@ describe('OrganizationService', () => {
     id: 'owner-1',
     email: 'owner@example.com',
     role: UserRole.COMPANY_OWNER,
+    status: UserStatus.ACTIVE,
+    organizationId: 'org-1',
+  };
+
+  const employee: AuthenticatedUserContext = {
+    id: 'employee-1',
+    email: 'employee@example.com',
+    role: UserRole.COMPANY_EMPLOYEE,
     status: UserStatus.ACTIVE,
     organizationId: 'org-1',
   };
@@ -140,6 +168,13 @@ describe('OrganizationService', () => {
     updatedAt: new Date('2026-01-02T00:00:00.000Z'),
   };
 
+  const updateDto = (
+    data: Partial<UpdateOrganizationProfileDto>,
+  ): UpdateOrganizationProfileDto => data as UpdateOrganizationProfileDto;
+
+  const runTransaction = (callback: (tx: object) => Promise<unknown>) =>
+    callback({});
+
   beforeEach(() => {
     organizationRepository = {
       findUnique: jest.fn(),
@@ -152,6 +187,10 @@ describe('OrganizationService', () => {
       findByEmail: jest.fn(),
       findAdmins: jest.fn(),
       updateOrganizationIfNotExists: jest.fn(),
+      findOrganizationMembers: jest.fn(),
+      findOrganizationMember: jest.fn(),
+      updateUserRole: jest.fn(),
+      update: jest.fn(),
     };
 
     queueService = {
@@ -210,6 +249,7 @@ describe('OrganizationService', () => {
       organizationRepository.findUnique.mockResolvedValue(existingOrganization);
 
       const result = await service.getMyOrganization(owner);
+
       expect(result.id).toBe(existingOrganization.id);
     });
   });
@@ -217,7 +257,7 @@ describe('OrganizationService', () => {
   describe('updateMyOrganization', () => {
     it('throws 404 when user has no organizationId', async () => {
       await expect(
-        service.updateMyOrganization({ name: 'X' } as any, {
+        service.updateMyOrganization(updateDto({ name: 'X' }), {
           ...owner,
           organizationId: null,
         }),
@@ -228,7 +268,7 @@ describe('OrganizationService', () => {
       organizationRepository.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.updateMyOrganization({ name: 'New Name' } as any, owner),
+        service.updateMyOrganization(updateDto({ name: 'New Name' }), owner),
       ).rejects.toBeInstanceOf(NotFoundException);
     });
 
@@ -236,7 +276,7 @@ describe('OrganizationService', () => {
       organizationRepository.findUnique.mockResolvedValue(existingOrganization);
 
       await expect(
-        service.updateMyOrganization({} as any, owner),
+        service.updateMyOrganization(updateDto({}), owner),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
@@ -247,7 +287,7 @@ describe('OrganizationService', () => {
       });
 
       await expect(
-        service.updateMyOrganization({ ico: '87654321' } as any, owner),
+        service.updateMyOrganization(updateDto({ ico: '87654321' }), owner),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
@@ -260,7 +300,7 @@ describe('OrganizationService', () => {
       });
 
       const result = await service.updateMyOrganization(
-        { sector: null, website: null } as any,
+        updateDto({ sector: null, website: null }),
         owner,
       );
 
@@ -272,19 +312,131 @@ describe('OrganizationService', () => {
     });
   });
 
-  it('lists invitations with computed EXPIRED status and pagination meta', async () => {
-    const now = new Date('2026-04-29T10:00:00.000Z');
-    jest.useFakeTimers().setSystemTime(now);
+  describe('organization invites', () => {
+    it('lists invitations with computed EXPIRED status and pagination meta', async () => {
+      const now = new Date('2026-04-29T10:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
 
-    organizationRepository.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'NTI',
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      organizationInviteRepository.findMany.mockResolvedValue([
+        {
+          id: 'invite-1',
+          email: 'expired@example.com',
+          token: 'token-1',
+          status: InvitationStatus.PENDING,
+          organizationId: 'org-1',
+          roleToAssign: UserRole.COMPANY_EMPLOYEE,
+          revokedById: null,
+          createdAt: new Date('2026-04-20T10:00:00.000Z'),
+          updatedAt: new Date('2026-04-20T10:00:00.000Z'),
+          expiresAt: new Date('2026-04-25T10:00:00.000Z'),
+          acceptedAt: null,
+          revokedAt: null,
+        },
+      ]);
+
+      organizationInviteRepository.count.mockResolvedValue(1);
+
+      const result = await service.listInvites(
+        'org-1',
+        { page: 1, limit: 20, sort: 'createdAt:desc' },
+        owner,
+      );
+
+      expect(organizationInviteRepository.findMany).toHaveBeenCalledWith({
+        where: { organizationId: 'org-1' },
+        orderBy: [{ createdAt: 'desc' }],
+        skip: 0,
+        take: 20,
+      });
+
+      expect(result).toEqual({
+        data: [
+          expect.objectContaining({
+            id: 'invite-1',
+            email: 'expired@example.com',
+            status: InvitationStatus.EXPIRED,
+          }),
+        ],
+        meta: {
+          page: 1,
+          limit: 20,
+          total: 1,
+          totalPages: 1,
+        },
+      });
     });
-    organizationInviteRepository.findMany.mockResolvedValue([
-      {
+
+    it('blocks access to invitations from another organization', async () => {
+      organizationRepository.findUnique.mockResolvedValue({
+        ...existingOrganization,
+        id: 'org-2',
+      });
+
+      await expect(
+        service.listInvites(
+          'org-2',
+          { page: 1, limit: 20, sort: 'createdAt:desc' },
+          owner,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('revokes a pending unexpired invite', async () => {
+      const now = new Date('2026-04-29T10:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      organizationInviteRepository.findByIdAndOrganization.mockResolvedValue({
         id: 'invite-1',
-        email: 'expired@example.com',
+        email: 'employee@example.com',
         token: 'token-1',
+        status: InvitationStatus.PENDING,
+        organizationId: 'org-1',
+        roleToAssign: UserRole.COMPANY_EMPLOYEE,
+        revokedById: null,
+        createdAt: new Date('2026-04-28T10:00:00.000Z'),
+        updatedAt: new Date('2026-04-28T10:00:00.000Z'),
+        expiresAt: new Date('2026-05-02T10:00:00.000Z'),
+        acceptedAt: null,
+        revokedAt: null,
+      });
+
+      organizationInviteRepository.update.mockResolvedValue({
+        id: 'invite-1',
+        revokedAt: now,
+      });
+
+      const result = await service.revokeInvite('org-1', 'invite-1', owner);
+
+      expect(organizationInviteRepository.update).toHaveBeenCalledWith(
+        { id: 'invite-1' },
+        {
+          status: InvitationStatus.REVOKED,
+          revokedAt: now,
+          revokedById: owner.id,
+        },
+      );
+
+      expect(result).toEqual({
+        id: 'invite-1',
+        status: 'REVOKED',
+        revokedAt: now,
+      });
+    });
+
+    it('rejects resend for an expired invite', async () => {
+      const now = new Date('2026-04-29T10:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      organizationInviteRepository.findByIdAndOrganization.mockResolvedValue({
+        id: 'invite-1',
+        email: 'employee@example.com',
+        token: 'old-token',
         status: InvitationStatus.PENDING,
         organizationId: 'org-1',
         roleToAssign: UserRole.COMPANY_EMPLOYEE,
@@ -294,177 +446,310 @@ describe('OrganizationService', () => {
         expiresAt: new Date('2026-04-25T10:00:00.000Z'),
         acceptedAt: null,
         revokedAt: null,
-      },
-    ]);
-    organizationInviteRepository.count.mockResolvedValue(1);
+      });
 
-    const result = await service.listInvites(
-      'org-1',
-      { page: 1, limit: 20, sort: 'createdAt:desc' },
-      owner,
-    );
-
-    expect(organizationInviteRepository.findMany).toHaveBeenCalledWith({
-      where: { organizationId: 'org-1' },
-      orderBy: [{ createdAt: 'desc' }],
-      skip: 0,
-      take: 20,
-    });
-    expect(result).toEqual({
-      data: [
-        expect.objectContaining({
-          id: 'invite-1',
-          email: 'expired@example.com',
-          status: InvitationStatus.EXPIRED,
-        }),
-      ],
-      meta: {
-        page: 1,
-        limit: 20,
-        total: 1,
-        totalPages: 1,
-      },
+      await expect(
+        service.resendInvite('org-1', 'invite-1', owner),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 
-  it('blocks access to invitations from another organization', async () => {
-    organizationRepository.findUnique.mockResolvedValue({
-      id: 'org-2',
-      name: 'Other Org',
-    });
+  describe('organization members', () => {
+    it('allows owner to list organization members', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
 
-    await expect(
-      service.listInvites(
-        'org-2',
-        { page: 1, limit: 20, sort: 'createdAt:desc' },
+      userRepository.findOrganizationMembers.mockResolvedValue([
         owner,
-      ),
-    ).rejects.toBeInstanceOf(ForbiddenException);
-  });
+        employee,
+      ]);
 
-  it('revokes a pending unexpired invite', async () => {
-    const now = new Date('2026-04-29T10:00:00.000Z');
-    jest.useFakeTimers().setSystemTime(now);
+      const result = await service.listMembers('org-1', owner);
 
-    organizationRepository.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'NTI',
-    });
-    organizationInviteRepository.findByIdAndOrganization.mockResolvedValue({
-      id: 'invite-1',
-      email: 'employee@example.com',
-      token: 'token-1',
-      status: InvitationStatus.PENDING,
-      organizationId: 'org-1',
-      roleToAssign: UserRole.COMPANY_EMPLOYEE,
-      revokedById: null,
-      createdAt: new Date('2026-04-28T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-28T10:00:00.000Z'),
-      expiresAt: new Date('2026-05-02T10:00:00.000Z'),
-      acceptedAt: null,
-      revokedAt: null,
-    });
-    organizationInviteRepository.update.mockResolvedValue({
-      id: 'invite-1',
-      revokedAt: now,
+      expect(userRepository.findOrganizationMembers).toHaveBeenCalledWith(
+        'org-1',
+      );
+      expect(result).toHaveLength(2);
     });
 
-    const result = await service.revokeInvite('org-1', 'invite-1', owner);
+    it('allows employee to list organization members from same organization', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
 
-    expect(organizationInviteRepository.update).toHaveBeenCalledWith(
-      { id: 'invite-1' },
-      {
-        status: InvitationStatus.REVOKED,
-        revokedAt: now,
-        revokedById: owner.id,
-      },
-    );
-    expect(result).toEqual({
-      id: 'invite-1',
-      status: 'REVOKED',
-      revokedAt: now,
-    });
-  });
+      userRepository.findOrganizationMembers.mockResolvedValue([
+        owner,
+        employee,
+      ]);
 
-  it('rejects resend for an expired invite', async () => {
-    const now = new Date('2026-04-29T10:00:00.000Z');
-    jest.useFakeTimers().setSystemTime(now);
+      const result = await service.listMembers('org-1', employee);
 
-    organizationRepository.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'NTI',
-    });
-    organizationInviteRepository.findByIdAndOrganization.mockResolvedValue({
-      id: 'invite-1',
-      email: 'employee@example.com',
-      token: 'old-token',
-      status: InvitationStatus.PENDING,
-      organizationId: 'org-1',
-      roleToAssign: UserRole.COMPANY_EMPLOYEE,
-      revokedById: null,
-      createdAt: new Date('2026-04-20T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-20T10:00:00.000Z'),
-      expiresAt: new Date('2026-04-25T10:00:00.000Z'),
-      acceptedAt: null,
-      revokedAt: null,
+      expect(userRepository.findOrganizationMembers).toHaveBeenCalledWith(
+        'org-1',
+      );
+      expect(result).toHaveLength(2);
     });
 
-    await expect(
-      service.resendInvite('org-1', 'invite-1', owner),
-    ).rejects.toBeInstanceOf(BadRequestException);
-  });
+    it('blocks cross-org member listing', async () => {
+      organizationRepository.findUnique.mockResolvedValue({
+        ...existingOrganization,
+        id: 'org-2',
+      });
 
-  it('resends a pending unexpired invite with a new token and expiry', async () => {
-    const now = new Date('2026-04-29T10:00:00.000Z');
-    const newExpiresAt = new Date('2026-05-06T10:00:00.000Z');
-    jest.useFakeTimers().setSystemTime(now);
-
-    organizationRepository.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'NTI',
-    });
-    organizationInviteRepository.findByIdAndOrganization.mockResolvedValue({
-      id: 'invite-1',
-      email: 'employee@example.com',
-      token: 'old-token',
-      status: InvitationStatus.PENDING,
-      organizationId: 'org-1',
-      roleToAssign: UserRole.COMPANY_EMPLOYEE,
-      revokedById: null,
-      createdAt: new Date('2026-04-28T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-28T10:00:00.000Z'),
-      expiresAt: new Date('2026-05-01T10:00:00.000Z'),
-      acceptedAt: null,
-      revokedAt: null,
-    });
-    hashingService.generateHexToken.mockReturnValue('new-token');
-    organizationInviteRepository.update.mockResolvedValue({
-      id: 'invite-1',
-      email: 'employee@example.com',
-      expiresAt: newExpiresAt,
+      await expect(service.listMembers('org-2', owner)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
     });
 
-    const result = await service.resendInvite('org-1', 'invite-1', owner);
+    it('allows owner to update employee role to employee', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
 
-    expect(hashingService.generateHexToken).toHaveBeenCalledWith(32);
-    expect(organizationInviteRepository.update).toHaveBeenCalledWith(
-      { id: 'invite-1' },
-      {
-        token: 'new-token',
-        status: InvitationStatus.PENDING,
-        expiresAt: newExpiresAt,
-      },
-    );
-    expect(queueService.addEmail).toHaveBeenCalledWith('org-invite', {
-      email: 'employee@example.com',
-      token: 'new-token',
-      organizationName: 'NTI',
+      userRepository.findOrganizationMember.mockResolvedValue(employee);
+
+      userRepository.updateUserRole.mockResolvedValue({
+        ...employee,
+        role: UserRole.COMPANY_EMPLOYEE,
+      });
+
+      const result = await service.updateMemberRole(
+        'org-1',
+        'employee-1',
+        { role: UserRole.COMPANY_EMPLOYEE },
+        owner,
+      );
+
+      expect(userRepository.updateUserRole).toHaveBeenCalledWith(
+        'employee-1',
+        UserRole.COMPANY_EMPLOYEE,
+      );
+
+      expect(result.role).toBe(UserRole.COMPANY_EMPLOYEE);
     });
-    expect(result).toEqual({
-      id: 'invite-1',
-      email: 'employee@example.com',
-      status: 'PENDING',
-      expiresAt: newExpiresAt,
+
+    it('blocks employee from updating member role', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      await expect(
+        service.updateMemberRole(
+          'org-1',
+          'owner-1',
+          { role: UserRole.COMPANY_EMPLOYEE },
+          employee,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('blocks setting COMPANY_OWNER through role update endpoint', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue(employee);
+
+      await expect(
+        service.updateMemberRole(
+          'org-1',
+          'employee-1',
+          { role: UserRole.COMPANY_OWNER },
+          owner,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('blocks direct role change of current owner', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue({
+        ...owner,
+        role: UserRole.COMPANY_OWNER,
+      });
+
+      await expect(
+        service.updateMemberRole(
+          'org-1',
+          'owner-1',
+          { role: UserRole.COMPANY_EMPLOYEE },
+          owner,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws 404 when member for role update is not found', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue(null);
+
+      await expect(
+        service.updateMemberRole(
+          'org-1',
+          'missing-user',
+          { role: UserRole.COMPANY_EMPLOYEE },
+          owner,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('removes non-owner member from organization', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue(employee);
+
+      userRepository.update.mockResolvedValue({
+        ...employee,
+        organizationId: null,
+        role: UserRole.STUDENT,
+      });
+
+      const result = await service.removeMember('org-1', 'employee-1', owner);
+
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { id: 'employee-1' },
+        {
+          organizationId: null,
+          role: UserRole.STUDENT,
+        },
+      );
+
+      expect(result.organizationId).toBeNull();
+      expect(result.role).toBe(UserRole.STUDENT);
+    });
+
+    it('blocks employee from removing member', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      await expect(
+        service.removeMember('org-1', 'owner-1', employee),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('blocks removing current owner', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue({
+        ...owner,
+        role: UserRole.COMPANY_OWNER,
+      });
+
+      await expect(
+        service.removeMember('org-1', 'owner-1', owner),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws 404 when removed member is not found', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      userRepository.findOrganizationMember.mockResolvedValue(null);
+
+      await expect(
+        service.removeMember('org-1', 'missing-user', owner),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('transfers ownership transactionally', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+      organizationRepository.transaction.mockImplementation(runTransaction);
+
+      userRepository.findOrganizationMember
+        .mockResolvedValueOnce({
+          ...owner,
+          role: UserRole.COMPANY_OWNER,
+          status: UserStatus.ACTIVE,
+        })
+        .mockResolvedValueOnce({
+          ...employee,
+          role: UserRole.COMPANY_EMPLOYEE,
+          status: UserStatus.ACTIVE,
+        });
+
+      userRepository.updateUserRole
+        .mockResolvedValueOnce({
+          ...owner,
+          role: UserRole.COMPANY_EMPLOYEE,
+        })
+        .mockResolvedValueOnce({
+          ...employee,
+          role: UserRole.COMPANY_OWNER,
+        });
+
+      const result = await service.transferOwner(
+        'org-1',
+        { newOwnerUserId: 'employee-1' },
+        owner,
+      );
+
+      expect(organizationRepository.transaction).toHaveBeenCalled();
+
+      expect(userRepository.updateUserRole).toHaveBeenNthCalledWith(
+        1,
+        'owner-1',
+        UserRole.COMPANY_EMPLOYEE,
+        expect.anything(),
+      );
+
+      expect(userRepository.updateUserRole).toHaveBeenNthCalledWith(
+        2,
+        'employee-1',
+        UserRole.COMPANY_OWNER,
+        expect.anything(),
+      );
+
+      expect(result.role).toBe(UserRole.COMPANY_OWNER);
+    });
+
+    it('blocks ownership transfer to current owner', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      await expect(
+        service.transferOwner('org-1', { newOwnerUserId: 'owner-1' }, owner),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('blocks employee from transferring ownership', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+
+      await expect(
+        service.transferOwner(
+          'org-1',
+          { newOwnerUserId: 'employee-1' },
+          employee,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws 404 when new owner is not organization member', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+      organizationRepository.transaction.mockImplementation(runTransaction);
+
+      userRepository.findOrganizationMember
+        .mockResolvedValueOnce({
+          ...owner,
+          role: UserRole.COMPANY_OWNER,
+          status: UserStatus.ACTIVE,
+        })
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.transferOwner(
+          'org-1',
+          { newOwnerUserId: 'missing-user' },
+          owner,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('blocks ownership transfer to suspended user', async () => {
+      organizationRepository.findUnique.mockResolvedValue(existingOrganization);
+      organizationRepository.transaction.mockImplementation(runTransaction);
+
+      userRepository.findOrganizationMember
+        .mockResolvedValueOnce({
+          ...owner,
+          role: UserRole.COMPANY_OWNER,
+          status: UserStatus.ACTIVE,
+        })
+        .mockResolvedValueOnce({
+          ...employee,
+          status: UserStatus.SUSPENDED,
+        });
+
+      await expect(
+        service.transferOwner('org-1', { newOwnerUserId: 'employee-1' }, owner),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 });

--- a/src/organization/organization.service.spec.ts
+++ b/src/organization/organization.service.spec.ts
@@ -115,6 +115,7 @@ describe('OrganizationService', () => {
     findOrganizationMember: jest.Mock;
     updateUserRole: jest.Mock;
     update: jest.Mock;
+    removeOrganizationMember: jest.Mock;
   };
 
   let queueService: {
@@ -192,6 +193,7 @@ describe('OrganizationService', () => {
       findOrganizationMember: jest.fn(),
       updateUserRole: jest.fn(),
       update: jest.fn(),
+      removeOrganizationMember: jest.fn(),
     };
 
     queueService = {
@@ -589,7 +591,7 @@ describe('OrganizationService', () => {
 
       userRepository.findOrganizationMember.mockResolvedValue(employee);
 
-      userRepository.update.mockResolvedValue({
+      userRepository.removeOrganizationMember.mockResolvedValue({
         ...employee,
         organizationId: null,
         role: UserRole.STUDENT,
@@ -597,12 +599,8 @@ describe('OrganizationService', () => {
 
       const result = await service.removeMember('org-1', 'employee-1', owner);
 
-      expect(userRepository.update).toHaveBeenCalledWith(
-        { id: 'employee-1' },
-        {
-          organizationId: null,
-          role: UserRole.STUDENT,
-        },
+      expect(userRepository.removeOrganizationMember).toHaveBeenCalledWith(
+        'employee-1',
       );
 
       expect(result.organizationId).toBeNull();

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -416,13 +416,7 @@ export class OrganizationService {
       throw new BadRequestException('Current owner cannot be removed');
     }
 
-    return this.userRepo.update(
-      { id: memberUserId },
-      {
-        organizationId: null,
-        role: UserRole.STUDENT,
-      },
-    );
+    return this.userRepo.removeOrganizationMember(memberUserId);
   }
 
   async transferOwner(

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -399,7 +399,9 @@ export class OrganizationService {
       throw new NotFoundException('Member not found');
     }
 
-    if (dto.role === UserRole.COMPANY_OWNER) {
+    const requestedRole = dto.role as UserRole;
+
+    if (requestedRole === UserRole.COMPANY_OWNER) {
       throw new BadRequestException(
         'Use ownership transfer endpoint to set company owner',
       );
@@ -411,7 +413,7 @@ export class OrganizationService {
       );
     }
 
-    return this.userRepo.updateUserRole(memberUserId, dto.role);
+    return this.userRepo.updateUserRole(memberUserId, requestedRole);
   }
 
   async removeMember(

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -10,6 +10,7 @@ import {
   InvitationStatus,
   OrganizationStatus,
   UserRole,
+  UserStatus,
 } from 'generated/prisma/enums';
 import { AuthenticatedUserContext } from 'src/common/types/auth-user-context.type';
 import { ConfigService } from 'src/infrastructure/config';
@@ -18,6 +19,8 @@ import { EMAIL_JOBS, QueueService } from 'src/infrastructure/queue';
 import { UserRepository } from 'src/user/user.repository';
 import { CreateOrganizationInviteDto } from './dto/create-organization-invite.dto';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
+import { UpdateOrganizationMemberRoleDto } from './dto/update-organization-member-role.dto';
+import { TransferOrganizationOwnerDto } from './dto/transfer-organization-owner.dto';
 import { GetOrganizationInvitesQueryDto } from './dto/get-organization-invites-query.dto';
 import { GetOrganizationInvitesResponseDto } from './dto/get-organization-invites-response.dto';
 import { OrganizationInviteItemDto } from './dto/organization-invite-item.dto';
@@ -373,6 +376,123 @@ export class OrganizationService {
     };
   }
 
+  async listMembers(organizationId: string, user: AuthenticatedUserContext) {
+    await this.ensureOrganizationMemberAccess(organizationId, user);
+
+    return this.userRepo.findOrganizationMembers(organizationId);
+  }
+
+  async updateMemberRole(
+    organizationId: string,
+    memberUserId: string,
+    dto: UpdateOrganizationMemberRoleDto,
+    user: AuthenticatedUserContext,
+  ) {
+    await this.ensureOrganizationOwnerAccess(organizationId, user);
+
+    const member = await this.userRepo.findOrganizationMember(
+      organizationId,
+      memberUserId,
+    );
+
+    if (!member) {
+      throw new NotFoundException('Member not found');
+    }
+
+    if (dto.role === UserRole.COMPANY_OWNER) {
+      throw new BadRequestException(
+        'Use ownership transfer endpoint to set company owner',
+      );
+    }
+
+    if (member.role === UserRole.COMPANY_OWNER) {
+      throw new BadRequestException(
+        'Current owner role cannot be changed directly',
+      );
+    }
+
+    return this.userRepo.updateUserRole(memberUserId, dto.role);
+  }
+
+  async removeMember(
+    organizationId: string,
+    memberUserId: string,
+    user: AuthenticatedUserContext,
+  ) {
+    await this.ensureOrganizationOwnerAccess(organizationId, user);
+
+    const member = await this.userRepo.findOrganizationMember(
+      organizationId,
+      memberUserId,
+    );
+
+    if (!member) {
+      throw new NotFoundException('Member not found');
+    }
+
+    if (member.role === UserRole.COMPANY_OWNER) {
+      throw new BadRequestException('Current owner cannot be removed');
+    }
+
+    return this.userRepo.update(
+      { id: memberUserId },
+      {
+        organizationId: null,
+        role: UserRole.STUDENT,
+      },
+    );
+  }
+
+  async transferOwner(
+    organizationId: string,
+    dto: TransferOrganizationOwnerDto,
+    user: AuthenticatedUserContext,
+  ) {
+    await this.ensureOrganizationOwnerAccess(organizationId, user);
+
+    if (dto.newOwnerUserId === user.id) {
+      throw new BadRequestException('User is already organization owner');
+    }
+
+    return this.organizationRepository.transaction(async (tx) => {
+      const currentOwner = await this.userRepo.findOrganizationMember(
+        organizationId,
+        user.id,
+        tx,
+      );
+
+      if (!currentOwner || currentOwner.role !== UserRole.COMPANY_OWNER) {
+        throw new ForbiddenException();
+      }
+
+      const newOwner = await this.userRepo.findOrganizationMember(
+        organizationId,
+        dto.newOwnerUserId,
+        tx,
+      );
+
+      if (!newOwner) {
+        throw new NotFoundException('New owner member not found');
+      }
+
+      if (newOwner.status !== UserStatus.ACTIVE) {
+        throw new BadRequestException('New owner must be active');
+      }
+
+      await this.userRepo.updateUserRole(
+        currentOwner.id,
+        UserRole.COMPANY_EMPLOYEE,
+        tx,
+      );
+
+      return this.userRepo.updateUserRole(
+        newOwner.id,
+        UserRole.COMPANY_OWNER,
+        tx,
+      );
+    });
+  }
+
   private generateToken(): string {
     return this.hashingService.generateHexToken(
       this.configService.tokenByteLength,
@@ -390,7 +510,7 @@ export class OrganizationService {
     );
   }
 
-  private async ensureOrganizationOwnerAccess(
+  private async ensureOrganizationMemberAccess(
     organizationId: string,
     user: AuthenticatedUserContext,
   ): Promise<Organization> {
@@ -403,6 +523,22 @@ export class OrganizationService {
     }
 
     if (user.organizationId !== organizationId) {
+      throw new ForbiddenException();
+    }
+
+    return organization;
+  }
+
+  private async ensureOrganizationOwnerAccess(
+    organizationId: string,
+    user: AuthenticatedUserContext,
+  ): Promise<Organization> {
+    const organization = await this.ensureOrganizationMemberAccess(
+      organizationId,
+      user,
+    );
+
+    if (user.role !== UserRole.COMPANY_OWNER) {
       throw new ForbiddenException();
     }
 

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -92,4 +92,45 @@ export class UserRepository extends BaseRepository<
       },
     });
   }
+
+  findOrganizationMembers(
+    organizationId: string,
+    db?: PrismaDbClient,
+  ): Promise<User[]> {
+    return this.getDelegate(db).findMany({
+      where: {
+        organizationId,
+        role: {
+          in: [UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE],
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+  }
+
+  findOrganizationMember(
+    organizationId: string,
+    userId: string,
+    db?: PrismaDbClient,
+  ): Promise<User | null> {
+    return this.getDelegate(db).findFirst({
+      where: {
+        id: userId,
+        organizationId,
+        role: {
+          in: [UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE],
+        },
+      },
+    });
+  }
+
+  updateUserRole(
+    userId: string,
+    role: UserRole,
+    db?: PrismaDbClient,
+  ): Promise<User> {
+    return this.update({ id: userId }, { role }, db);
+  }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -11,6 +11,22 @@ import {
 } from '../infrastructure/database/base.repository';
 import { PrismaService } from '../infrastructure/database/prisma.service';
 
+const organizationMemberSelect = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  email: true,
+  role: true,
+  status: true,
+  organizationId: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.UserSelect;
+
+export type OrganizationMemberRecord = Prisma.UserGetPayload<{
+  select: typeof organizationMemberSelect;
+}>;
+
 @Injectable()
 export class UserRepository extends BaseRepository<
   User,
@@ -96,7 +112,7 @@ export class UserRepository extends BaseRepository<
   findOrganizationMembers(
     organizationId: string,
     db?: PrismaDbClient,
-  ): Promise<User[]> {
+  ): Promise<OrganizationMemberRecord[]> {
     return this.getDelegate(db).findMany({
       where: {
         organizationId,
@@ -107,6 +123,7 @@ export class UserRepository extends BaseRepository<
       orderBy: {
         createdAt: 'asc',
       },
+      select: organizationMemberSelect,
     });
   }
 
@@ -114,7 +131,7 @@ export class UserRepository extends BaseRepository<
     organizationId: string,
     userId: string,
     db?: PrismaDbClient,
-  ): Promise<User | null> {
+  ): Promise<OrganizationMemberRecord | null> {
     return this.getDelegate(db).findFirst({
       where: {
         id: userId,
@@ -123,6 +140,7 @@ export class UserRepository extends BaseRepository<
           in: [UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE],
         },
       },
+      select: organizationMemberSelect,
     });
   }
 
@@ -130,7 +148,25 @@ export class UserRepository extends BaseRepository<
     userId: string,
     role: UserRole,
     db?: PrismaDbClient,
-  ): Promise<User> {
-    return this.update({ id: userId }, { role }, db);
+  ): Promise<OrganizationMemberRecord> {
+    return this.getDelegate(db).update({
+      where: { id: userId },
+      data: { role },
+      select: organizationMemberSelect,
+    });
+  }
+
+  removeOrganizationMember(
+    userId: string,
+    db?: PrismaDbClient,
+  ): Promise<OrganizationMemberRecord> {
+    return this.getDelegate(db).update({
+      where: { id: userId },
+      data: {
+        organizationId: null,
+        role: UserRole.STUDENT,
+      },
+      select: organizationMemberSelect,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Added endpoint to list organization members
- Added endpoint to update organization member role
- Added endpoint to remove a non-owner organization member
- Added endpoint to transfer organization ownership transactionally
- Added Swagger documentation for organization member lifecycle endpoints
- Added service tests for organization member lifecycle rules

## Tests
- npm run typescript
- npm test -- organization.service.spec.ts
- npm run build
- npx eslint src/organization/organization.service.spec.ts src/organization/api-docs/organization-api-docs.decorators.ts