### PR TITLE
feat: implement needs-info workflow

### DIFF
--- a/prisma/migrations/20260507225357_add_needs_info_workflow/migration.sql
+++ b/prisma/migrations/20260507225357_add_needs_info_workflow/migration.sql
@@ -1,0 +1,78 @@
+-- CreateEnum
+CREATE TYPE "NeedsInfoItemStatus" AS ENUM ('OPEN', 'ANSWERED', 'RESOLVED');
+
+-- CreateTable
+CREATE TABLE "NeedsInfoItem" (
+    "id" TEXT NOT NULL,
+    "applicationId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "dueAt" TIMESTAMP(3),
+    "status" "NeedsInfoItemStatus" NOT NULL DEFAULT 'OPEN',
+    "createdById" TEXT NOT NULL,
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NeedsInfoItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NeedsInfoReply" (
+    "id" TEXT NOT NULL,
+    "needsInfoItemId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NeedsInfoReply_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApplicationStatusEvent" (
+    "id" TEXT NOT NULL,
+    "applicationId" TEXT NOT NULL,
+    "fromStatus" "ApplicationStatus" NOT NULL,
+    "toStatus" "ApplicationStatus" NOT NULL,
+    "changedById" TEXT NOT NULL,
+    "reason" TEXT,
+    "needsInfoItemId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ApplicationStatusEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "NeedsInfoItem_applicationId_createdAt_idx" ON "NeedsInfoItem"("applicationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "NeedsInfoItem_applicationId_status_idx" ON "NeedsInfoItem"("applicationId", "status");
+
+-- CreateIndex
+CREATE INDEX "NeedsInfoReply_needsInfoItemId_createdAt_idx" ON "NeedsInfoReply"("needsInfoItemId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ApplicationStatusEvent_applicationId_createdAt_idx" ON "ApplicationStatusEvent"("applicationId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "NeedsInfoItem" ADD CONSTRAINT "NeedsInfoItem_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NeedsInfoItem" ADD CONSTRAINT "NeedsInfoItem_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NeedsInfoItem" ADD CONSTRAINT "NeedsInfoItem_resolvedById_fkey" FOREIGN KEY ("resolvedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NeedsInfoReply" ADD CONSTRAINT "NeedsInfoReply_needsInfoItemId_fkey" FOREIGN KEY ("needsInfoItemId") REFERENCES "NeedsInfoItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NeedsInfoReply" ADD CONSTRAINT "NeedsInfoReply_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApplicationStatusEvent" ADD CONSTRAINT "ApplicationStatusEvent_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApplicationStatusEvent" ADD CONSTRAINT "ApplicationStatusEvent_changedById_fkey" FOREIGN KEY ("changedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "ApplicationDocument_applicationId_memberUserId_documentType_isA" RENAME TO "ApplicationDocument_applicationId_memberUserId_documentType_idx";

--- a/prisma/migrations/20260508111154_add_needs_info_status_event_relation/migration.sql
+++ b/prisma/migrations/20260508111154_add_needs_info_status_event_relation/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "ApplicationStatusEvent_needsInfoItemId_idx" ON "ApplicationStatusEvent"("needsInfoItemId");
+
+-- AddForeignKey
+ALTER TABLE "ApplicationStatusEvent" ADD CONSTRAINT "ApplicationStatusEvent_needsInfoItemId_fkey" FOREIGN KEY ("needsInfoItemId") REFERENCES "NeedsInfoItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -373,7 +373,8 @@ model NeedsInfoItem {
 
   createdAt DateTime @default(now())
 
-  replies NeedsInfoReply[]
+  replies      NeedsInfoReply[]
+  statusEvents ApplicationStatusEvent[]
 
   @@index([applicationId, createdAt])
   @@index([applicationId, status])
@@ -407,9 +408,12 @@ model ApplicationStatusEvent {
 
   reason          String?
   needsInfoItemId String?
-  createdAt       DateTime @default(now())
+  needsInfoItem   NeedsInfoItem? @relation(fields: [needsInfoItemId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
 
   @@index([applicationId, createdAt])
+  @@index([needsInfoItemId])
 }
 
 enum InvitationStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,12 @@ enum StudentSoftSkill {
   PROJECT_COORDINATION
 }
 
+enum NeedsInfoItemStatus {
+  OPEN
+  ANSWERED
+  RESOLVED
+}
+
 model User {
   id                 String  @id @default(uuid())
   firstName          String
@@ -177,6 +183,11 @@ model User {
   applicationsCreated           Application[]         @relation("ApplicationCreatedBy")
   applicationDocumentsCreated   ApplicationDocument[] @relation("ApplicationDocumentCreatedBy")
   applicationDocumentsForMember ApplicationDocument[] @relation("ApplicationDocumentMember")
+
+  needsInfoItemsCreated          NeedsInfoItem[]          @relation("NeedsInfoCreatedBy")
+  needsInfoItemsResolved         NeedsInfoItem[]          @relation("NeedsInfoResolvedBy")
+  needsInfoRepliesCreated        NeedsInfoReply[]         @relation("NeedsInfoReplyCreatedBy")
+  applicationStatusEventsChanged ApplicationStatusEvent[] @relation("ApplicationStatusChangedBy")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -283,6 +294,9 @@ model Application {
   createdBy   User                  @relation("ApplicationCreatedBy", fields: [createdById], references: [id])
   documents   ApplicationDocument[]
 
+  needsInfoItems NeedsInfoItem[]
+  statusEvents   ApplicationStatusEvent[]
+
   status      ApplicationStatus @default(DRAFT)
   submittedAt DateTime?
   decidedAt   DateTime?
@@ -338,6 +352,64 @@ model ApplicationDocument {
   @@index([applicationId, documentScope, isActive])
   @@index([applicationId, memberUserId, documentType, isActive])
   @@index([uploadedFileId])
+}
+
+model NeedsInfoItem {
+  id            String      @id @default(uuid())
+  applicationId String
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+
+  message String
+  dueAt   DateTime?
+
+  status NeedsInfoItemStatus @default(OPEN)
+
+  createdById String
+  createdBy   User   @relation("NeedsInfoCreatedBy", fields: [createdById], references: [id])
+
+  resolvedAt   DateTime?
+  resolvedById String?
+  resolvedBy   User?     @relation("NeedsInfoResolvedBy", fields: [resolvedById], references: [id])
+
+  createdAt DateTime @default(now())
+
+  replies NeedsInfoReply[]
+
+  @@index([applicationId, createdAt])
+  @@index([applicationId, status])
+}
+
+model NeedsInfoReply {
+  id              String        @id @default(uuid())
+  needsInfoItemId String
+  needsInfoItem   NeedsInfoItem @relation(fields: [needsInfoItemId], references: [id], onDelete: Cascade)
+
+  message String
+
+  createdById String
+  createdBy   User   @relation("NeedsInfoReplyCreatedBy", fields: [createdById], references: [id])
+
+  createdAt DateTime @default(now())
+
+  @@index([needsInfoItemId, createdAt])
+}
+
+model ApplicationStatusEvent {
+  id            String      @id @default(uuid())
+  applicationId String
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+
+  fromStatus ApplicationStatus
+  toStatus   ApplicationStatus
+
+  changedById String
+  changedBy   User   @relation("ApplicationStatusChangedBy", fields: [changedById], references: [id])
+
+  reason          String?
+  needsInfoItemId String?
+  createdAt       DateTime @default(now())
+
+  @@index([applicationId, createdAt])
 }
 
 enum InvitationStatus {

--- a/src/applications/api-docs/applications-api-docs.decorators.ts
+++ b/src/applications/api-docs/applications-api-docs.decorators.ts
@@ -11,8 +11,14 @@ import { ApplicationDetailDto } from '../dto/application-detail.dto';
 import { ApplicationDocumentDto } from '../dto/application-document.dto';
 import { AttachApplicationDocumentDto } from '../dto/attach-application-document.dto';
 import { CreateApplicationDto } from '../dto/create-application.dto';
+import { CreateNeedsInfoItemDto } from '../dto/create-needs-info-item.dto';
+import { CreateNeedsInfoReplyDto } from '../dto/create-needs-info-reply.dto';
 import { DocumentCompletenessDto } from '../dto/document-completeness.dto';
+import { NeedsInfoItemDto } from '../dto/needs-info-item.dto';
+import { NeedsInfoReplyDto } from '../dto/needs-info-reply.dto';
+import { NeedsInfoThreadDto } from '../dto/needs-info-thread.dto';
 import { RequiredDocumentsResponseDto } from '../dto/required-documents-response.dto';
+import { ResubmitApplicationDto } from '../dto/resubmit-application.dto';
 
 export const CreateApplicationApi = () =>
   createApiDecorator({
@@ -153,6 +159,112 @@ export const SubmitApplicationApi = () =>
       ApiConflictResponse({
         description:
           'Call is not open for applications, application is not in a submittable state, or required documents are missing.',
+      }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const CreateNeedsInfoItemApi = () =>
+  createApiDecorator({
+    summary: 'Request additional information for application',
+    description:
+      'Reviewer-side users can request additional information for submitted applications. The application moves to NEEDS_INFO.',
+    body: CreateNeedsInfoItemDto,
+    successResponse: {
+      status: 201,
+      type: NeedsInfoItemDto,
+      description: 'Needs-info item was created.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description: 'Invalid application id or invalid application status.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'Only reviewer-side users can request additional information.',
+      }),
+      ApiConflictResponse({
+        description: 'Application status was changed concurrently.',
+      }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const ReplyToNeedsInfoItemApi = () =>
+  createApiDecorator({
+    summary: 'Reply to needs-info item',
+    description:
+      'Team lead can reply to an open needs-info item while the application is in NEEDS_INFO status.',
+    body: CreateNeedsInfoReplyDto,
+    successResponse: {
+      status: 201,
+      type: NeedsInfoReplyDto,
+      description: 'Needs-info reply was created.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description: 'Invalid id format or application is not in NEEDS_INFO.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only team lead can reply to needs-info requests.',
+      }),
+      ApiConflictResponse({
+        description: 'Needs-info item is already resolved.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Application or needs-info item was not found.',
+      }),
+    ],
+  });
+
+export const ResubmitApplicationApi = () =>
+  createApiDecorator({
+    summary: 'Resubmit application after needs-info replies',
+    description:
+      'Team lead can resubmit an application from NEEDS_INFO to EVALUATING after all needs-info items have been answered.',
+    body: ResubmitApplicationDto,
+    successResponse: {
+      status: 200,
+      type: ApplicationDetailDto,
+      description: 'Application was resubmitted.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description:
+          'Application is not in NEEDS_INFO, has no unresolved needs-info items, or still has open items.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only team lead can resubmit the application.',
+      }),
+      ApiConflictResponse({
+        description: 'Application status was changed concurrently.',
+      }),
+      ApiNotFoundResponse({ description: 'Application was not found.' }),
+    ],
+  });
+
+export const GetNeedsInfoThreadApi = () =>
+  createApiDecorator({
+    summary: 'Get needs-info thread',
+    description:
+      'Returns needs-info items, replies, and application status events for the application.',
+    successResponse: {
+      status: 200,
+      type: NeedsInfoThreadDto,
+      description: 'Needs-info thread.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({ description: 'Invalid application id format.' }),
+      ApiForbiddenResponse({
+        description: 'User has no access to this application.',
       }),
       ApiNotFoundResponse({ description: 'Application was not found.' }),
     ],

--- a/src/applications/api-docs/index.ts
+++ b/src/applications/api-docs/index.ts
@@ -1,8 +1,12 @@
 export {
   AttachApplicationDocumentApi,
   CreateApplicationApi,
+  CreateNeedsInfoItemApi,
   GetApplicationApi,
   GetApplicationDocumentCompletenessApi,
+  GetNeedsInfoThreadApi,
   GetRequiredDocumentsApi,
+  ReplyToNeedsInfoItemApi,
+  ResubmitApplicationApi,
   SubmitApplicationApi,
 } from './applications-api-docs.decorators';

--- a/src/applications/applications.controller.ts
+++ b/src/applications/applications.controller.ts
@@ -24,7 +24,10 @@ import { ApplicationDetailDto } from './dto/application-detail.dto';
 import { ApplicationDocumentDto } from './dto/application-document.dto';
 import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
+import { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
+import { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
 import { DocumentCompletenessDto } from './dto/document-completeness.dto';
+import { ResubmitApplicationDto } from './dto/resubmit-application.dto';
 import { ApplicationsService } from './applications.service';
 
 @ApiTags('Applications')
@@ -78,5 +81,42 @@ export class ApplicationsController {
     @GetUserContext() user: AuthenticatedUserContext,
   ): Promise<ApplicationDetailDto> {
     return this.applicationsService.submit(id, user);
+  }
+
+  @Post(':id/needs-info-items')
+  createNeedsInfoItem(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: CreateNeedsInfoItemDto,
+  ) {
+    return this.applicationsService.createNeedsInfoItem(id, user, dto);
+  }
+
+  @Post(':id/needs-info-items/:itemId/replies')
+  replyToNeedsInfoItem(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('itemId', ParseUUIDPipe) itemId: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: CreateNeedsInfoReplyDto,
+  ) {
+    return this.applicationsService.replyToNeedsInfoItem(id, itemId, user, dto);
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post(':id/resubmit')
+  resubmit(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: ResubmitApplicationDto,
+  ): Promise<ApplicationDetailDto> {
+    return this.applicationsService.resubmit(id, user, dto);
+  }
+
+  @Get(':id/needs-info-thread')
+  getNeedsInfoThread(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ) {
+    return this.applicationsService.getNeedsInfoThread(id, user);
   }
 }

--- a/src/applications/applications.controller.ts
+++ b/src/applications/applications.controller.ts
@@ -16,8 +16,12 @@ import type { AuthenticatedUserContext } from '../common/types/auth-user-context
 import {
   AttachApplicationDocumentApi,
   CreateApplicationApi,
+  CreateNeedsInfoItemApi,
   GetApplicationApi,
   GetApplicationDocumentCompletenessApi,
+  GetNeedsInfoThreadApi,
+  ReplyToNeedsInfoItemApi,
+  ResubmitApplicationApi,
   SubmitApplicationApi,
 } from './api-docs';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
@@ -27,6 +31,9 @@ import { CreateApplicationDto } from './dto/create-application.dto';
 import { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
 import { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
 import { DocumentCompletenessDto } from './dto/document-completeness.dto';
+import { NeedsInfoItemDto } from './dto/needs-info-item.dto';
+import { NeedsInfoReplyDto } from './dto/needs-info-reply.dto';
+import { NeedsInfoThreadDto } from './dto/needs-info-thread.dto';
 import { ResubmitApplicationDto } from './dto/resubmit-application.dto';
 import { ApplicationsService } from './applications.service';
 
@@ -83,25 +90,28 @@ export class ApplicationsController {
     return this.applicationsService.submit(id, user);
   }
 
+  @CreateNeedsInfoItemApi()
   @Post(':id/needs-info-items')
   createNeedsInfoItem(
     @Param('id', ParseUUIDPipe) id: string,
     @GetUserContext() user: AuthenticatedUserContext,
     @Body() dto: CreateNeedsInfoItemDto,
-  ) {
+  ): Promise<NeedsInfoItemDto> {
     return this.applicationsService.createNeedsInfoItem(id, user, dto);
   }
 
+  @ReplyToNeedsInfoItemApi()
   @Post(':id/needs-info-items/:itemId/replies')
   replyToNeedsInfoItem(
     @Param('id', ParseUUIDPipe) id: string,
     @Param('itemId', ParseUUIDPipe) itemId: string,
     @GetUserContext() user: AuthenticatedUserContext,
     @Body() dto: CreateNeedsInfoReplyDto,
-  ) {
+  ): Promise<NeedsInfoReplyDto> {
     return this.applicationsService.replyToNeedsInfoItem(id, itemId, user, dto);
   }
 
+  @ResubmitApplicationApi()
   @HttpCode(HttpStatus.OK)
   @Post(':id/resubmit')
   resubmit(
@@ -112,11 +122,12 @@ export class ApplicationsController {
     return this.applicationsService.resubmit(id, user, dto);
   }
 
+  @GetNeedsInfoThreadApi()
   @Get(':id/needs-info-thread')
   getNeedsInfoThread(
     @Param('id', ParseUUIDPipe) id: string,
     @GetUserContext() user: AuthenticatedUserContext,
-  ) {
+  ): Promise<NeedsInfoThreadDto> {
     return this.applicationsService.getNeedsInfoThread(id, user);
   }
 }

--- a/src/applications/applications.module.ts
+++ b/src/applications/applications.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { NeedsInfoRepository } from './needs-info.repository';
 import { AuthModule } from '../auth/auth.module';
 import { FilesModule } from '../files/files.module';
 import { CallsDocumentsController } from './calls-documents.controller';
@@ -14,6 +15,7 @@ import { TeamModule } from '../team/team.module';
   imports: [AuthModule, TeamModule, FilesModule],
   controllers: [ApplicationsController, CallsDocumentsController],
   providers: [
+    NeedsInfoRepository,
     ApplicationsRepository,
     ApplicationDocumentsRepository,
     CallsRepository,

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -100,6 +100,23 @@ export class ApplicationsRepository extends BaseRepository<
     );
   }
 
+  updateStatusIfCurrent(
+    id: string,
+    currentStatus: ApplicationStatus,
+    nextStatus: ApplicationStatus,
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).application.updateMany({
+      where: {
+        id,
+        status: currentStatus,
+      },
+      data: {
+        status: nextStatus,
+      },
+    });
+  }
+
   private applicationDetailSelect() {
     return {
       id: true,

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -175,6 +175,17 @@ describe('ApplicationsService', () => {
       callsRepository as never,
       teamRepository as never,
       filesRepository as never,
+      {
+        createItem: jest.fn(),
+        findItemForApplication: jest.fn(),
+        createReply: jest.fn(),
+        markItemAnswered: jest.fn(),
+        findUnresolvedItems: jest.fn(),
+        resolveAnsweredItems: jest.fn(),
+        getThread: jest.fn(),
+        getStatusEvents: jest.fn(),
+        createStatusEvent: jest.fn(),
+      } as never,
     );
   });
 

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -10,6 +10,7 @@ import {
   ApplicationDocumentScope,
   ApplicationStatus,
   DocumentType,
+  NeedsInfoItemStatus,
   ProgramType,
   UploadStatus,
   UserRole,
@@ -23,14 +24,18 @@ import { ApplicationDetailDto } from './dto/application-detail.dto';
 import { ApplicationDocumentDto } from './dto/application-document.dto';
 import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
+import { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
+import { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
 import { DocumentCompletenessDto } from './dto/document-completeness.dto';
 import { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';
+import { ResubmitApplicationDto } from './dto/resubmit-application.dto';
 import {
   ApplicationWithRelations,
   ApplicationsRepository,
   ApplicationWorkflowView,
 } from './applications.repository';
 import { CallsRepository } from './calls.repository';
+import { NeedsInfoRepository } from './needs-info.repository';
 
 type RequiredDocumentSlot = {
   documentType: DocumentType;
@@ -44,6 +49,10 @@ export class ApplicationsService {
     isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
   } as const;
 
+  private readonly needsInfoTransactionOptions = {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  } as const;
+
   constructor(
     private readonly applicationsRepository: ApplicationsRepository,
     private readonly applicationDocumentsRepository: ApplicationDocumentsRepository,
@@ -51,6 +60,7 @@ export class ApplicationsService {
     private readonly callsRepository: CallsRepository,
     private readonly teamRepository: TeamRepository,
     private readonly filesRepository: FilesRepository,
+    private readonly needsInfoRepository: NeedsInfoRepository,
   ) {}
 
   async createDraft(
@@ -288,6 +298,239 @@ export class ApplicationsService {
     return this.toDetailDto(submitted);
   }
 
+  async createNeedsInfoItem(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+    dto: CreateNeedsInfoItemDto,
+  ) {
+    if (!this.isReviewerSideUser(user)) {
+      throw new ForbiddenException(
+        'Only reviewer-side users can request additional information',
+      );
+    }
+
+    return this.applicationsRepository.transaction(async (db) => {
+      const application = await this.loadWorkflowApplicationOrThrow(
+        applicationId,
+        db,
+      );
+
+      const allowedStatuses: ApplicationStatus[] = [
+        ApplicationStatus.SUBMITTED,
+        ApplicationStatus.FORMALLY_VERIFIED,
+        ApplicationStatus.EVALUATING,
+      ];
+
+      if (!allowedStatuses.includes(application.status)) {
+        throw new BadRequestException(
+          `Needs-info request is not allowed for application status ${application.status}`,
+        );
+      }
+
+      const item = await this.needsInfoRepository.createItem(
+        {
+          applicationId: application.id,
+          message: dto.message,
+          dueAt: dto.dueAt ? new Date(dto.dueAt) : null,
+          createdById: user.id,
+        },
+        db,
+      );
+
+      const updated = await this.applicationsRepository.updateStatusIfCurrent(
+        application.id,
+        application.status,
+        ApplicationStatus.NEEDS_INFO,
+        db,
+      );
+
+      if (updated.count !== 1) {
+        throw new ConflictException(
+          'Application status was changed concurrently. Please retry.',
+        );
+      }
+
+      await this.needsInfoRepository.createStatusEvent(
+        {
+          applicationId: application.id,
+          fromStatus: application.status,
+          toStatus: ApplicationStatus.NEEDS_INFO,
+          changedById: user.id,
+          reason: dto.message,
+          needsInfoItemId: item.id,
+        },
+        db,
+      );
+
+      return item;
+    }, this.needsInfoTransactionOptions);
+  }
+
+  async replyToNeedsInfoItem(
+    applicationId: string,
+    itemId: string,
+    user: AuthenticatedUserContext,
+    dto: CreateNeedsInfoReplyDto,
+  ) {
+    return this.applicationsRepository.transaction(async (db) => {
+      const application = await this.loadWorkflowApplicationOrThrow(
+        applicationId,
+        db,
+      );
+
+      this.ensureApplicationManagedByTeamLead(application, user.id);
+
+      const item = await this.needsInfoRepository.findItemForApplication(
+        application.id,
+        itemId,
+        db,
+      );
+
+      if (!item) {
+        throw new NotFoundException('Needs-info item not found');
+      }
+
+      if (item.status === NeedsInfoItemStatus.RESOLVED) {
+        throw new ConflictException('Needs-info item is already resolved');
+      }
+
+      const reply = await this.needsInfoRepository.createReply(
+        {
+          needsInfoItemId: item.id,
+          message: dto.message,
+          createdById: user.id,
+        },
+        db,
+      );
+
+      if (item.status === NeedsInfoItemStatus.OPEN) {
+        await this.needsInfoRepository.markItemAnswered(item.id, db);
+      }
+
+      return reply;
+    }, this.needsInfoTransactionOptions);
+  }
+
+  async resubmit(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+    dto: ResubmitApplicationDto,
+  ): Promise<ApplicationDetailDto> {
+    const updatedApplication = await this.applicationsRepository.transaction(
+      async (db) => {
+        const application = await this.loadWorkflowApplicationOrThrow(
+          applicationId,
+          db,
+        );
+
+        this.ensureApplicationManagedByTeamLead(application, user.id);
+
+        if (application.status !== ApplicationStatus.NEEDS_INFO) {
+          throw new BadRequestException(
+            'Application can be resubmitted only from NEEDS_INFO status',
+          );
+        }
+
+        const unresolvedItems =
+          await this.needsInfoRepository.findUnresolvedItems(
+            application.id,
+            db,
+          );
+
+        if (unresolvedItems.length === 0) {
+          throw new BadRequestException(
+            'Application has no unresolved needs-info items',
+          );
+        }
+
+        const hasOpenItems = unresolvedItems.some(
+          (item) => item.status === NeedsInfoItemStatus.OPEN,
+        );
+
+        if (hasOpenItems) {
+          throw new BadRequestException(
+            'Application cannot be resubmitted while some needs-info items are still open',
+          );
+        }
+
+        const now = new Date();
+
+        await this.needsInfoRepository.resolveAnsweredItems(
+          application.id,
+          user.id,
+          now,
+          db,
+        );
+
+        const updated = await this.applicationsRepository.updateStatusIfCurrent(
+          application.id,
+          ApplicationStatus.NEEDS_INFO,
+          ApplicationStatus.EVALUATING,
+          db,
+        );
+
+        if (updated.count !== 1) {
+          throw new ConflictException(
+            'Application status was changed concurrently. Please retry.',
+          );
+        }
+
+        await this.needsInfoRepository.createStatusEvent(
+          {
+            applicationId: application.id,
+            fromStatus: ApplicationStatus.NEEDS_INFO,
+            toStatus: ApplicationStatus.EVALUATING,
+            changedById: user.id,
+            reason:
+              dto.message ?? 'Application resubmitted after needs-info replies',
+          },
+          db,
+        );
+
+        const refreshed =
+          await this.applicationsRepository.findByIdWithRelations(
+            application.id,
+            db,
+          );
+
+        if (!refreshed) {
+          throw new NotFoundException('Application not found');
+        }
+
+        return refreshed;
+      },
+      this.needsInfoTransactionOptions,
+    );
+
+    return this.toDetailDto(updatedApplication);
+  }
+
+  async getNeedsInfoThread(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+  ) {
+    const application =
+      await this.loadWorkflowApplicationOrThrow(applicationId);
+
+    this.validateNeedsInfoThreadAccess(application, user);
+
+    const [items, statusEvents] = await Promise.all([
+      this.needsInfoRepository.getThread(application.id),
+      this.needsInfoRepository.getStatusEvents(application.id),
+    ]);
+
+    return {
+      application: {
+        id: application.id,
+        status: application.status,
+        teamId: application.teamId,
+        callId: application.callId,
+      },
+      items,
+      statusEvents,
+    };
+  }
+
   private async loadWorkflowApplicationOrThrow(
     applicationId: string,
     db?: Parameters<ApplicationsRepository['findByIdForWorkflow']>[1],
@@ -302,6 +545,35 @@ export class ApplicationsService {
     }
 
     return application;
+  }
+
+  private isReviewerSideUser(user: AuthenticatedUserContext): boolean {
+    const reviewerRoles: UserRole[] = [
+      UserRole.EVALUATOR,
+      UserRole.ADMIN,
+      UserRole.SUPER_ADMIN,
+    ];
+
+    return reviewerRoles.includes(user.role);
+  }
+
+  private validateNeedsInfoThreadAccess(
+    application: ApplicationWorkflowView,
+    user: AuthenticatedUserContext,
+  ): void {
+    if (this.isReviewerSideUser(user)) {
+      return;
+    }
+
+    const isTeamMember =
+      application.team.leaderId === user.id ||
+      application.team.members.some((member) => member.userId === user.id);
+
+    if (!isTeamMember) {
+      throw new ForbiddenException(
+        'You do not have access to this application',
+      );
+    }
   }
 
   private ensureProgramADocumentWorkflow(application: ApplicationWorkflowView) {

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -22,11 +22,15 @@ import { ApplicationDocumentsRepository } from './application-documents.reposito
 import { ApplicationRulesService } from './application-rules.service';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
 import { ApplicationDocumentDto } from './dto/application-document.dto';
+import { ApplicationStatusEventDto } from './dto/application-status-event.dto';
 import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
 import { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
 import { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
 import { DocumentCompletenessDto } from './dto/document-completeness.dto';
+import { NeedsInfoItemDto } from './dto/needs-info-item.dto';
+import { NeedsInfoReplyDto } from './dto/needs-info-reply.dto';
+import { NeedsInfoThreadDto } from './dto/needs-info-thread.dto';
 import { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';
 import { ResubmitApplicationDto } from './dto/resubmit-application.dto';
 import {
@@ -302,7 +306,7 @@ export class ApplicationsService {
     applicationId: string,
     user: AuthenticatedUserContext,
     dto: CreateNeedsInfoItemDto,
-  ) {
+  ): Promise<NeedsInfoItemDto> {
     if (!this.isReviewerSideUser(user)) {
       throw new ForbiddenException(
         'Only reviewer-side users can request additional information',
@@ -362,7 +366,10 @@ export class ApplicationsService {
         db,
       );
 
-      return item;
+      return this.toNeedsInfoItemDto({
+        ...item,
+        replies: [],
+      });
     }, this.needsInfoTransactionOptions);
   }
 
@@ -371,14 +378,20 @@ export class ApplicationsService {
     itemId: string,
     user: AuthenticatedUserContext,
     dto: CreateNeedsInfoReplyDto,
-  ) {
+  ): Promise<NeedsInfoReplyDto> {
     return this.applicationsRepository.transaction(async (db) => {
       const application = await this.loadWorkflowApplicationOrThrow(
         applicationId,
         db,
       );
 
-      this.ensureApplicationManagedByTeamLead(application, user.id);
+      this.ensureApplicationManagedByTeamLeadForNeedsInfo(application, user.id);
+
+      if (application.status !== ApplicationStatus.NEEDS_INFO) {
+        throw new BadRequestException(
+          'Needs-info replies are allowed only while application is in NEEDS_INFO status',
+        );
+      }
 
       const item = await this.needsInfoRepository.findItemForApplication(
         application.id,
@@ -407,7 +420,7 @@ export class ApplicationsService {
         await this.needsInfoRepository.markItemAnswered(item.id, db);
       }
 
-      return reply;
+      return this.toNeedsInfoReplyDto(reply);
     }, this.needsInfoTransactionOptions);
   }
 
@@ -423,7 +436,10 @@ export class ApplicationsService {
           db,
         );
 
-        this.ensureApplicationManagedByTeamLead(application, user.id);
+        this.ensureApplicationManagedByTeamLeadForNeedsInfo(
+          application,
+          user.id,
+        );
 
         if (application.status !== ApplicationStatus.NEEDS_INFO) {
           throw new BadRequestException(
@@ -508,7 +524,7 @@ export class ApplicationsService {
   async getNeedsInfoThread(
     applicationId: string,
     user: AuthenticatedUserContext,
-  ) {
+  ): Promise<NeedsInfoThreadDto> {
     const application =
       await this.loadWorkflowApplicationOrThrow(applicationId);
 
@@ -526,8 +542,10 @@ export class ApplicationsService {
         teamId: application.teamId,
         callId: application.callId,
       },
-      items,
-      statusEvents,
+      items: items.map((item) => this.toNeedsInfoItemDto(item)),
+      statusEvents: statusEvents.map((event) =>
+        this.toApplicationStatusEventDto(event),
+      ),
     };
   }
 
@@ -591,6 +609,17 @@ export class ApplicationsService {
     if (application.team.leaderId !== userId) {
       throw new ForbiddenException(
         'Only team lead can manage application documents and submission',
+      );
+    }
+  }
+
+  private ensureApplicationManagedByTeamLeadForNeedsInfo(
+    application: ApplicationWorkflowView,
+    userId: string,
+  ): void {
+    if (application.team.leaderId !== userId) {
+      throw new ForbiddenException(
+        'Only team lead can reply to needs-info requests and resubmit the application',
       );
     }
   }
@@ -806,6 +835,78 @@ export class ApplicationsService {
       uploadStatus: document.uploadedFile.status,
       uploadedFileOwnerId: document.uploadedFile.ownerId,
       createdAt: document.createdAt,
+    };
+  }
+
+  private toNeedsInfoReplyDto(reply: {
+    id: string;
+    needsInfoItemId: string;
+    message: string;
+    createdById: string;
+    createdAt: Date;
+  }): NeedsInfoReplyDto {
+    return {
+      id: reply.id,
+      needsInfoItemId: reply.needsInfoItemId,
+      message: reply.message,
+      createdById: reply.createdById,
+      createdAt: reply.createdAt,
+    };
+  }
+
+  private toNeedsInfoItemDto(item: {
+    id: string;
+    applicationId: string;
+    message: string;
+    dueAt: Date | null;
+    status: NeedsInfoItemStatus;
+    createdById: string;
+    resolvedAt: Date | null;
+    resolvedById: string | null;
+    createdAt: Date;
+    replies?: {
+      id: string;
+      needsInfoItemId: string;
+      message: string;
+      createdById: string;
+      createdAt: Date;
+    }[];
+  }): NeedsInfoItemDto {
+    return {
+      id: item.id,
+      applicationId: item.applicationId,
+      message: item.message,
+      dueAt: item.dueAt,
+      status: item.status,
+      createdById: item.createdById,
+      resolvedAt: item.resolvedAt,
+      resolvedById: item.resolvedById,
+      createdAt: item.createdAt,
+      replies: (item.replies ?? []).map((reply) =>
+        this.toNeedsInfoReplyDto(reply),
+      ),
+    };
+  }
+
+  private toApplicationStatusEventDto(event: {
+    id: string;
+    applicationId: string;
+    fromStatus: ApplicationStatus;
+    toStatus: ApplicationStatus;
+    changedById: string;
+    reason: string | null;
+    needsInfoItemId: string | null;
+    createdAt: Date;
+  }): ApplicationStatusEventDto {
+    return {
+      id: event.id,
+      applicationId: event.applicationId,
+      fromStatus: event.fromStatus,
+      toStatus: event.toStatus,
+      changedById: event.changedById,
+      reason: event.reason,
+      needsInfoItemId: event.needsInfoItemId,
+      createdAt: event.createdAt,
     };
   }
 

--- a/src/applications/dto/application-status-event.dto.ts
+++ b/src/applications/dto/application-status-event.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ApplicationStatus } from '../../../generated/prisma/enums';
+
+export class ApplicationStatusEventDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  applicationId!: string;
+
+  @ApiProperty({ enum: ApplicationStatus })
+  fromStatus!: ApplicationStatus;
+
+  @ApiProperty({ enum: ApplicationStatus })
+  toStatus!: ApplicationStatus;
+
+  @ApiProperty()
+  changedById!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  reason!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  needsInfoItemId!: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/src/applications/dto/create-needs-info-item.dto.ts
+++ b/src/applications/dto/create-needs-info-item.dto.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateNeedsInfoItemDto {
+  @IsString()
+  @MinLength(1)
+  message: string;
+
+  @IsOptional()
+  @IsDateString()
+  dueAt?: string;
+}

--- a/src/applications/dto/create-needs-info-reply.dto.ts
+++ b/src/applications/dto/create-needs-info-reply.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class CreateNeedsInfoReplyDto {
+  @IsString()
+  @MinLength(1)
+  message: string;
+}

--- a/src/applications/dto/needs-info-item.dto.ts
+++ b/src/applications/dto/needs-info-item.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { NeedsInfoItemStatus } from '../../../generated/prisma/enums';
+import { NeedsInfoReplyDto } from './needs-info-reply.dto';
+
+export class NeedsInfoItemDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  applicationId!: string;
+
+  @ApiProperty()
+  message!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  dueAt!: Date | null;
+
+  @ApiProperty({ enum: NeedsInfoItemStatus })
+  status!: NeedsInfoItemStatus;
+
+  @ApiProperty()
+  createdById!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  resolvedAt!: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  resolvedById!: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty({ type: [NeedsInfoReplyDto] })
+  replies!: NeedsInfoReplyDto[];
+}

--- a/src/applications/dto/needs-info-reply.dto.ts
+++ b/src/applications/dto/needs-info-reply.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NeedsInfoReplyDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  needsInfoItemId!: string;
+
+  @ApiProperty()
+  message!: string;
+
+  @ApiProperty()
+  createdById!: string;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/src/applications/dto/needs-info-thread.dto.ts
+++ b/src/applications/dto/needs-info-thread.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ApplicationStatus } from '../../../generated/prisma/enums';
+import { ApplicationStatusEventDto } from './application-status-event.dto';
+import { NeedsInfoItemDto } from './needs-info-item.dto';
+
+class NeedsInfoThreadApplicationDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ enum: ApplicationStatus })
+  status!: ApplicationStatus;
+
+  @ApiProperty()
+  teamId!: string;
+
+  @ApiProperty()
+  callId!: string;
+}
+
+export class NeedsInfoThreadDto {
+  @ApiProperty({ type: NeedsInfoThreadApplicationDto })
+  application!: NeedsInfoThreadApplicationDto;
+
+  @ApiProperty({ type: [NeedsInfoItemDto] })
+  items!: NeedsInfoItemDto[];
+
+  @ApiProperty({ type: [ApplicationStatusEventDto] })
+  statusEvents!: ApplicationStatusEventDto[];
+}

--- a/src/applications/dto/resubmit-application.dto.ts
+++ b/src/applications/dto/resubmit-application.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class ResubmitApplicationDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  message?: string;
+}

--- a/src/applications/index.ts
+++ b/src/applications/index.ts
@@ -22,3 +22,7 @@ export { DocumentCompletenessDto } from './dto/document-completeness.dto';
 export { DocumentCompletenessItemDto } from './dto/document-completeness-item.dto';
 export { RequiredDocumentTypeDto } from './dto/required-document-type.dto';
 export { RequiredDocumentsResponseDto } from './dto/required-documents-response.dto';
+export { NeedsInfoRepository } from './needs-info.repository';
+export { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
+export { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
+export { ResubmitApplicationDto } from './dto/resubmit-application.dto';

--- a/src/applications/index.ts
+++ b/src/applications/index.ts
@@ -26,3 +26,7 @@ export { NeedsInfoRepository } from './needs-info.repository';
 export { CreateNeedsInfoItemDto } from './dto/create-needs-info-item.dto';
 export { CreateNeedsInfoReplyDto } from './dto/create-needs-info-reply.dto';
 export { ResubmitApplicationDto } from './dto/resubmit-application.dto';
+export { ApplicationStatusEventDto } from './dto/application-status-event.dto';
+export { NeedsInfoItemDto } from './dto/needs-info-item.dto';
+export { NeedsInfoReplyDto } from './dto/needs-info-reply.dto';
+export { NeedsInfoThreadDto } from './dto/needs-info-thread.dto';

--- a/src/applications/needs-info.repository.ts
+++ b/src/applications/needs-info.repository.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ApplicationStatus,
+  NeedsInfoItemStatus,
+} from '../../generated/prisma/enums';
+import { PrismaDbClient } from '../infrastructure/database';
+import { PrismaService } from '../infrastructure/database/prisma.service';
+
+@Injectable()
+export class NeedsInfoRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  createItem(
+    data: {
+      applicationId: string;
+      message: string;
+      dueAt?: Date | null;
+      createdById: string;
+    },
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).needsInfoItem.create({
+      data: {
+        applicationId: data.applicationId,
+        message: data.message,
+        dueAt: data.dueAt ?? null,
+        createdById: data.createdById,
+      },
+    });
+  }
+
+  findItemForApplication(
+    applicationId: string,
+    itemId: string,
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).needsInfoItem.findFirst({
+      where: {
+        id: itemId,
+        applicationId,
+      },
+      include: {
+        replies: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+  }
+
+  createReply(
+    data: {
+      needsInfoItemId: string;
+      message: string;
+      createdById: string;
+    },
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).needsInfoReply.create({
+      data: {
+        needsInfoItemId: data.needsInfoItemId,
+        message: data.message,
+        createdById: data.createdById,
+      },
+    });
+  }
+
+  markItemAnswered(itemId: string, db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).needsInfoItem.update({
+      where: {
+        id: itemId,
+      },
+      data: {
+        status: NeedsInfoItemStatus.ANSWERED,
+      },
+    });
+  }
+
+  findUnresolvedItems(applicationId: string, db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).needsInfoItem.findMany({
+      where: {
+        applicationId,
+        status: {
+          in: [NeedsInfoItemStatus.OPEN, NeedsInfoItemStatus.ANSWERED],
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+  }
+
+  resolveAnsweredItems(
+    applicationId: string,
+    resolvedById: string,
+    resolvedAt: Date,
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).needsInfoItem.updateMany({
+      where: {
+        applicationId,
+        status: NeedsInfoItemStatus.ANSWERED,
+      },
+      data: {
+        status: NeedsInfoItemStatus.RESOLVED,
+        resolvedById,
+        resolvedAt,
+      },
+    });
+  }
+
+  getThread(applicationId: string, db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).needsInfoItem.findMany({
+      where: {
+        applicationId,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+      include: {
+        replies: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+  }
+
+  createStatusEvent(
+    data: {
+      applicationId: string;
+      fromStatus: ApplicationStatus;
+      toStatus: ApplicationStatus;
+      changedById: string;
+      reason?: string | null;
+      needsInfoItemId?: string | null;
+    },
+    db?: PrismaDbClient,
+  ) {
+    return (db ?? this.prisma.client).applicationStatusEvent.create({
+      data: {
+        applicationId: data.applicationId,
+        fromStatus: data.fromStatus,
+        toStatus: data.toStatus,
+        changedById: data.changedById,
+        reason: data.reason ?? null,
+        needsInfoItemId: data.needsInfoItemId ?? null,
+      },
+    });
+  }
+
+  getStatusEvents(applicationId: string, db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).applicationStatusEvent.findMany({
+      where: {
+        applicationId,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implemented Needs Info workflow for applications.

### Added
- NeedsInfoItem, NeedsInfoReply, ApplicationStatusEvent Prisma models
- NeedsInfoItemStatus enum
- Create needs-info item endpoint
- Reply to needs-info item endpoint
- Resubmit application endpoint
- Needs-info thread endpoint
- Transactional application status changes
- Status history events

### Endpoints
- POST /api/v1/applications/:id/needs-info-items
- POST /api/v1/applications/:id/needs-info-items/:itemId/replies
- POST /api/v1/applications/:id/resubmit
- GET /api/v1/applications/:id/needs-info-thread

### Checks
- npm run typescript ✅
- npm run lint ✅
- npm run test ✅

Closes #50