### PR TITLE
feat(admin): implement paginated listing for organizations and users

### DIFF
--- a/src/admin/dto/admin-list-meta.dto.ts
+++ b/src/admin/dto/admin-list-meta.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginatedMetaDto } from '../../common/pagination';
+
+export class AdminListMetaDto extends PaginatedMetaDto {
+  @ApiProperty({ example: 'createdAt' })
+  sort!: string;
+
+  @ApiProperty({ example: 'desc', enum: ['asc', 'desc'] })
+  order!: string;
+}

--- a/src/admin/organizations/admin-organizations.controller.spec.ts
+++ b/src/admin/organizations/admin-organizations.controller.spec.ts
@@ -11,16 +11,19 @@ import type { AuthenticatedUserContext } from '../../common/types/auth-user-cont
 import { AdminOrganizationsController } from './admin-organizations.controller';
 import { AdminOrganizationsService } from './admin-organizations.service';
 import { MANAGEABLE_ORG_STATUSES } from './dto/update-org-status.dto';
+import type { ListOrganizationsQueryDto } from './dto/list-organizations-query.dto';
 
 describe('AdminOrganizationsController', () => {
   let controller: AdminOrganizationsController;
   let adminOrganizationsService: {
+    listOrganizations: jest.Mock;
     updateStatus: jest.Mock;
     getOrganization: jest.Mock;
   };
 
   beforeEach(() => {
     adminOrganizationsService = {
+      listOrganizations: jest.fn(),
       updateStatus: jest.fn(),
       getOrganization: jest.fn(),
     };
@@ -28,6 +31,52 @@ describe('AdminOrganizationsController', () => {
     controller = new AdminOrganizationsController(
       adminOrganizationsService as unknown as AdminOrganizationsService,
     );
+  });
+
+  it('returns the paginated organizations list', async () => {
+    const actor: AuthenticatedUserContext = {
+      id: 'admin-1',
+      email: 'admin@example.com',
+      role: UserRole.ADMIN,
+      status: UserStatus.ACTIVE,
+      organizationId: null,
+    };
+    const query: ListOrganizationsQueryDto = {
+      page: 1,
+      limit: 20,
+      sort: 'createdAt',
+      order: 'desc',
+    };
+    const response = {
+      data: [
+        {
+          id: 'org-1',
+          name: 'Acme Labs s.r.o.',
+          ico: '12345678',
+          status: OrganizationStatus.ACTIVE,
+          sector: null,
+          membersCount: 3,
+          createdAt: new Date(),
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        sort: 'createdAt',
+        order: 'desc',
+      },
+    };
+    adminOrganizationsService.listOrganizations.mockResolvedValue(response);
+
+    const result = await controller.getOrganizations(actor, query);
+
+    expect(adminOrganizationsService.listOrganizations).toHaveBeenCalledWith(
+      actor,
+      query,
+    );
+    expect(result).toEqual(response);
   });
 
   it('returns updated organization payload', async () => {

--- a/src/admin/organizations/admin-organizations.controller.ts
+++ b/src/admin/organizations/admin-organizations.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   ParseUUIDPipe,
   Patch,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -16,12 +17,15 @@ import { RolesGuard } from '../../auth/guards/roles.guard';
 import type { AuthenticatedUserContext } from '../../common/types/auth-user-context.type';
 import {
   GetAdminOrganizationApi,
+  GetAdminOrganizationsApi,
   UpdateOrganizationStatusApi,
 } from './api-docs/admin-organizations-api-docs.decorators';
 import { AdminOrganizationsService } from './admin-organizations.service';
 import { AdminOrganizationResponseDto } from './dto/admin-organization-response.dto';
 import { OrganizationStatusResponseDto } from './dto/organization-status-response.dto';
 import { UpdateOrgStatusDto } from './dto/update-org-status.dto';
+import { ListOrganizationsQueryDto } from './dto/list-organizations-query.dto';
+import type { ListOrganizationsResponseDto } from './dto/list-organizations-response.dto';
 
 @ApiTags('Admin')
 @Controller('admin/organizations')
@@ -29,6 +33,17 @@ export class AdminOrganizationsController {
   constructor(
     private readonly adminOrganizationsService: AdminOrganizationsService,
   ) {}
+
+  @GetAdminOrganizationsApi()
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  getOrganizations(
+    @GetUserContext() actor: AuthenticatedUserContext,
+    @Query() query: ListOrganizationsQueryDto,
+  ): Promise<ListOrganizationsResponseDto> {
+    return this.adminOrganizationsService.listOrganizations(actor, query);
+  }
 
   @GetAdminOrganizationApi()
   @Get(':id')

--- a/src/admin/organizations/admin-organizations.service.spec.ts
+++ b/src/admin/organizations/admin-organizations.service.spec.ts
@@ -28,12 +28,14 @@ import { OrganizationRepository } from '../../organization/organization.reposito
 import { UserRepository } from '../../user/user.repository';
 import { AdminOrganizationsService } from './admin-organizations.service';
 import { MANAGEABLE_ORG_STATUSES } from './dto/update-org-status.dto';
+import type { ListOrganizationsQueryDto } from './dto/list-organizations-query.dto';
 
 describe('AdminOrganizationsService', () => {
   let service: AdminOrganizationsService;
   let organizationRepository: {
     findUnique: jest.Mock;
     updateMany: jest.Mock;
+    findManyForAdminPaginated: jest.Mock;
   };
   let userRepository: {
     findOrganizationOwner: jest.Mock;
@@ -71,10 +73,18 @@ describe('AdminOrganizationsService', () => {
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   };
 
+  const defaultQuery: ListOrganizationsQueryDto = {
+    page: 1,
+    limit: 20,
+    sort: 'createdAt',
+    order: 'desc',
+  };
+
   beforeEach(() => {
     organizationRepository = {
       findUnique: jest.fn(),
       updateMany: jest.fn(),
+      findManyForAdminPaginated: jest.fn(),
     };
 
     userRepository = {
@@ -90,6 +100,47 @@ describe('AdminOrganizationsService', () => {
       userRepository as unknown as UserRepository,
       queueService as unknown as QueueService,
     );
+  });
+
+  describe('listOrganizations', () => {
+    it('returns paginated organization list for admins', async () => {
+      organizationRepository.findManyForAdminPaginated.mockResolvedValue({
+        data: [{ ...pendingOrganization, membersCount: 3 }],
+        total: 1,
+      });
+
+      const result = await service.listOrganizations(actorAdmin, defaultQuery);
+
+      expect(
+        organizationRepository.findManyForAdminPaginated,
+      ).toHaveBeenCalled();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: pendingOrganization.id,
+        name: pendingOrganization.name,
+        ico: pendingOrganization.ico,
+        status: pendingOrganization.status,
+        membersCount: 3,
+      });
+      expect(result.meta).toMatchObject({
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        sort: 'createdAt',
+        order: 'desc',
+      });
+    });
+
+    it('throws forbidden when non-admin requests organizations list', async () => {
+      await expect(
+        service.listOrganizations(actorStudent, defaultQuery),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(
+        organizationRepository.findManyForAdminPaginated,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   it('throws when actor is not an administrator', async () => {

--- a/src/admin/organizations/admin-organizations.service.spec.ts
+++ b/src/admin/organizations/admin-organizations.service.spec.ts
@@ -141,6 +141,76 @@ describe('AdminOrganizationsService', () => {
         organizationRepository.findManyForAdminPaginated,
       ).not.toHaveBeenCalled();
     });
+
+    it('passes q search as OR filter on name and ico', async () => {
+      organizationRepository.findManyForAdminPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listOrganizations(actorAdmin, {
+        ...defaultQuery,
+        q: 'acme',
+      });
+
+      expect(
+        organizationRepository.findManyForAdminPaginated,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [
+              { name: { contains: 'acme', mode: 'insensitive' } },
+              { ico: { contains: 'acme', mode: 'insensitive' } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('passes status and sector as exact/contains filters', async () => {
+      organizationRepository.findManyForAdminPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listOrganizations(actorAdmin, {
+        ...defaultQuery,
+        status: OrganizationStatus.ACTIVE,
+        sector: 'IT',
+      });
+
+      expect(
+        organizationRepository.findManyForAdminPaginated,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: OrganizationStatus.ACTIVE,
+            sector: { contains: 'IT', mode: 'insensitive' },
+          },
+        }),
+      );
+    });
+
+    it('passes sort and order to repository as orderBy', async () => {
+      organizationRepository.findManyForAdminPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listOrganizations(actorAdmin, {
+        ...defaultQuery,
+        sort: 'name',
+        order: 'asc',
+      });
+
+      expect(
+        organizationRepository.findManyForAdminPaginated,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ name: 'asc' }, { id: 'asc' }],
+        }),
+      );
+    });
   });
 
   it('throws when actor is not an administrator', async () => {

--- a/src/admin/organizations/admin-organizations.service.ts
+++ b/src/admin/organizations/admin-organizations.service.ts
@@ -4,9 +4,15 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '../../../generated/prisma/client';
 import { OrganizationStatus } from '../../../generated/prisma/enums';
 import { ensureAdminRole } from '../../auth/admin-role.helper';
 import type { AuthenticatedUserContext } from '../../common/types/auth-user-context.type';
+import {
+  buildOrderBy,
+  buildPaginationMeta,
+  resolvePagination,
+} from '../../common/pagination';
 import { EMAIL_JOBS, QueueService } from '../../infrastructure/queue';
 import { OrganizationRepository } from '../../organization/organization.repository';
 import { UserRepository } from '../../user/user.repository';
@@ -16,6 +22,8 @@ import {
   MANAGEABLE_ORG_STATUSES,
   UpdateOrgStatusDto,
 } from './dto/update-org-status.dto';
+import type { ListOrganizationsQueryDto } from './dto/list-organizations-query.dto';
+import type { ListOrganizationsResponseDto } from './dto/list-organizations-response.dto';
 
 @Injectable()
 export class AdminOrganizationsService {
@@ -26,6 +34,54 @@ export class AdminOrganizationsService {
     private readonly userRepository: UserRepository,
     private readonly queueService: QueueService,
   ) {}
+
+  async listOrganizations(
+    actor: AuthenticatedUserContext,
+    query: ListOrganizationsQueryDto,
+  ): Promise<ListOrganizationsResponseDto> {
+    ensureAdminRole(actor.role, 'Only administrators can access organizations');
+
+    const where: Prisma.OrganizationWhereInput = {
+      ...(query.q && {
+        OR: [
+          { name: { contains: query.q, mode: 'insensitive' } },
+          { ico: { contains: query.q, mode: 'insensitive' } },
+        ],
+      }),
+      ...(query.status && { status: query.status }),
+      ...(query.sector && {
+        sector: { contains: query.sector, mode: 'insensitive' },
+      }),
+    };
+
+    const orderBy = buildOrderBy(query.sort, query.order, [{ id: 'asc' }]);
+    const pagination = resolvePagination(query);
+
+    const { data, total } =
+      await this.organizationRepository.findManyForAdminPaginated({
+        where,
+        orderBy,
+        skip: pagination.skip,
+        take: pagination.take,
+      });
+
+    return {
+      data: data.map((org) => ({
+        id: org.id,
+        name: org.name,
+        ico: org.ico,
+        status: org.status,
+        sector: org.sector,
+        membersCount: org.membersCount,
+        createdAt: org.createdAt,
+      })),
+      meta: {
+        ...buildPaginationMeta(total, pagination.page, pagination.limit),
+        sort: query.sort,
+        order: query.order,
+      },
+    };
+  }
 
   async getOrganization(
     actor: AuthenticatedUserContext,

--- a/src/admin/organizations/api-docs/admin-organizations-api-docs.decorators.ts
+++ b/src/admin/organizations/api-docs/admin-organizations-api-docs.decorators.ts
@@ -3,8 +3,10 @@ import {
   ApiBearerAuth,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
+  ApiQuery,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { OrganizationStatus } from '../../../../generated/prisma/enums';
 import { createApiDecorator } from '../../../infrastructure/api-docs/api-docs-factory';
 import { createPaginationQueryDecorators } from '../../../common/pagination';
 import { AdminOrganizationResponseDto } from '../dto/admin-organization-response.dto';
@@ -30,8 +32,29 @@ export const GetAdminOrganizationsApi = () =>
         defaultSort: 'createdAt',
         defaultOrder: 'desc',
       }),
+      ApiQuery({
+        name: 'q',
+        required: false,
+        type: String,
+        description: 'Search by organization name or ICO.',
+      }),
+      ApiQuery({
+        name: 'status',
+        required: false,
+        enum: OrganizationStatus,
+        description: 'Filter by organization status.',
+      }),
+      ApiQuery({
+        name: 'sector',
+        required: false,
+        type: String,
+        description: 'Filter by sector (partial, case-insensitive match).',
+      }),
     ],
     errors: [
+      ApiBadRequestResponse({
+        description: 'Query parameters are invalid.',
+      }),
       ApiUnauthorizedResponse({
         description: 'Bearer token is missing or invalid.',
       }),

--- a/src/admin/organizations/api-docs/admin-organizations-api-docs.decorators.ts
+++ b/src/admin/organizations/api-docs/admin-organizations-api-docs.decorators.ts
@@ -6,9 +6,40 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { createApiDecorator } from '../../../infrastructure/api-docs/api-docs-factory';
+import { createPaginationQueryDecorators } from '../../../common/pagination';
 import { AdminOrganizationResponseDto } from '../dto/admin-organization-response.dto';
+import { ListOrganizationsResponseDto } from '../dto/list-organizations-response.dto';
 import { OrganizationStatusResponseDto } from '../dto/organization-status-response.dto';
 import { UpdateOrgStatusDto } from '../dto/update-org-status.dto';
+import { ORG_SORT_VALUES } from '../dto/list-organizations-query.dto';
+
+export const GetAdminOrganizationsApi = () =>
+  createApiDecorator({
+    summary: 'List organizations (admin)',
+    description:
+      'Returns a paginated, filterable, and sortable list of all organizations for administrators.',
+    successResponse: {
+      status: 200,
+      type: ListOrganizationsResponseDto,
+      description: 'Paginated organization list.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ...createPaginationQueryDecorators({
+        sortValues: ORG_SORT_VALUES,
+        defaultSort: 'createdAt',
+        defaultOrder: 'desc',
+      }),
+    ],
+    errors: [
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only administrators can access this resource.',
+      }),
+    ],
+  });
 
 export const GetAdminOrganizationApi = () =>
   createApiDecorator({

--- a/src/admin/organizations/dto/admin-organization-row.dto.ts
+++ b/src/admin/organizations/dto/admin-organization-row.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrganizationStatus } from '../../../../generated/prisma/enums';
+
+export class AdminOrganizationRowDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ example: 'Acme Corp' })
+  name!: string;
+
+  @ApiProperty({ example: '12345678' })
+  ico!: string;
+
+  @ApiProperty({ enum: OrganizationStatus })
+  status!: OrganizationStatus;
+
+  @ApiPropertyOptional({ type: String, nullable: true, example: 'IT' })
+  sector!: string | null;
+
+  @ApiProperty({
+    description: 'Number of users belonging to this organization.',
+    example: 5,
+  })
+  membersCount!: number;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt!: Date;
+}

--- a/src/admin/organizations/dto/list-organizations-query.dto.ts
+++ b/src/admin/organizations/dto/list-organizations-query.dto.ts
@@ -1,0 +1,43 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { OrganizationStatus } from '../../../../generated/prisma/enums';
+import {
+  PaginationQueryDto,
+  SORT_ORDER_VALUES,
+  type SortOrder,
+} from '../../../common/pagination';
+
+export const ORG_SORT_VALUES = ['createdAt', 'name', 'status'] as const;
+export type OrgSortField = (typeof ORG_SORT_VALUES)[number];
+
+export class ListOrganizationsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Search by name or ICO.',
+    example: 'Acme',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  q?: string;
+
+  @ApiPropertyOptional({ enum: OrganizationStatus })
+  @IsOptional()
+  @IsEnum(OrganizationStatus)
+  status?: OrganizationStatus;
+
+  @ApiPropertyOptional({ example: 'IT' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  sector?: string;
+
+  @ApiPropertyOptional({ enum: ORG_SORT_VALUES, default: 'createdAt' })
+  @IsOptional()
+  @IsIn(ORG_SORT_VALUES)
+  sort: OrgSortField = 'createdAt';
+
+  @ApiPropertyOptional({ enum: SORT_ORDER_VALUES, default: 'desc' })
+  @IsOptional()
+  @IsIn(SORT_ORDER_VALUES)
+  order: SortOrder = 'desc';
+}

--- a/src/admin/organizations/dto/list-organizations-query.dto.ts
+++ b/src/admin/organizations/dto/list-organizations-query.dto.ts
@@ -1,4 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsEnum, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
 import { OrganizationStatus } from '../../../../generated/prisma/enums';
 import {
@@ -17,6 +18,9 @@ export class ListOrganizationsQueryDto extends PaginationQueryDto {
   })
   @IsOptional()
   @IsString()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @MaxLength(120)
   q?: string;
 
@@ -28,6 +32,9 @@ export class ListOrganizationsQueryDto extends PaginationQueryDto {
   @ApiPropertyOptional({ example: 'IT' })
   @IsOptional()
   @IsString()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @MaxLength(120)
   sector?: string;
 

--- a/src/admin/organizations/dto/list-organizations-response.dto.ts
+++ b/src/admin/organizations/dto/list-organizations-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminListMetaDto } from '../../dto/admin-list-meta.dto';
+import { AdminOrganizationRowDto } from './admin-organization-row.dto';
+
+export class ListOrganizationsResponseDto {
+  @ApiProperty({ type: [AdminOrganizationRowDto] })
+  data!: AdminOrganizationRowDto[];
+
+  @ApiProperty({ type: AdminListMetaDto })
+  meta!: AdminListMetaDto;
+}

--- a/src/admin/users/admin-users.controller.spec.ts
+++ b/src/admin/users/admin-users.controller.spec.ts
@@ -7,18 +7,19 @@ import type { AuthenticatedUserContext } from '../../common/types/auth-user-cont
 import { AdminUsersController } from './admin-users.controller';
 import { AdminUsersService } from './admin-users.service';
 import { MANAGEABLE_USER_STATUSES } from './dto/update-user-status.dto';
+import type { ListUsersQueryDto } from './dto/list-users-query.dto';
 
 describe('AdminUsersController', () => {
   let controller: AdminUsersController;
   let adminUsersService: {
-    getUsers: jest.Mock;
+    listUsers: jest.Mock;
     getUserById: jest.Mock;
     updateStatus: jest.Mock;
   };
 
   beforeEach(() => {
     adminUsersService = {
-      getUsers: jest.fn(),
+      listUsers: jest.fn(),
       getUserById: jest.fn(),
       updateStatus: jest.fn(),
     };
@@ -61,7 +62,7 @@ describe('AdminUsersController', () => {
     });
   });
 
-  it('returns the safe users list', async () => {
+  it('returns the paginated users list', async () => {
     const actor: AuthenticatedUserContext = {
       id: 'admin-1',
       email: 'admin@example.com',
@@ -69,27 +70,40 @@ describe('AdminUsersController', () => {
       status: UserStatus.ACTIVE,
       organizationId: null,
     };
-
-    const users = [
-      {
-        id: 'user-1',
-        email: 'user1@example.com',
-        role: UserRole.STUDENT,
-        status: UserStatus.ACTIVE,
+    const query: ListUsersQueryDto = {
+      page: 1,
+      limit: 20,
+      sort: 'createdAt',
+      order: 'desc',
+    };
+    const response = {
+      data: [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          firstName: 'Alice',
+          lastName: 'Smith',
+          role: UserRole.STUDENT,
+          status: UserStatus.ACTIVE,
+          organizationId: null,
+          createdAt: new Date(),
+        },
+      ],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        sort: 'createdAt',
+        order: 'desc',
       },
-      {
-        id: 'user-2',
-        email: 'user2@example.com',
-        role: UserRole.COMPANY_OWNER,
-        status: UserStatus.PENDING,
-      },
-    ];
-    adminUsersService.getUsers.mockResolvedValue(users);
+    };
+    adminUsersService.listUsers.mockResolvedValue(response);
 
-    const result = await controller.getUsers(actor);
+    const result = await controller.getUsers(actor, query);
 
-    expect(adminUsersService.getUsers).toHaveBeenCalledWith(actor);
-    expect(result).toEqual(users);
+    expect(adminUsersService.listUsers).toHaveBeenCalledWith(actor, query);
+    expect(result).toEqual(response);
   });
 
   it('returns one safe user by id', async () => {

--- a/src/admin/users/admin-users.controller.ts
+++ b/src/admin/users/admin-users.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   ParseUUIDPipe,
   Patch,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -21,6 +22,8 @@ import {
 } from './api-docs/admin-users-api-docs.decorators';
 import { AdminUsersService } from './admin-users.service';
 import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import { ListUsersQueryDto } from './dto/list-users-query.dto';
+import type { ListUsersResponseDto } from './dto/list-users-response.dto';
 
 @ApiTags('Admin')
 @Controller('admin/users')
@@ -33,8 +36,9 @@ export class AdminUsersController {
   @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
   getUsers(
     @GetUserContext() actor: AuthenticatedUserContext,
-  ): Promise<AuthenticatedUserContext[]> {
-    return this.adminUsersService.getUsers(actor);
+    @Query() query: ListUsersQueryDto,
+  ): Promise<ListUsersResponseDto> {
+    return this.adminUsersService.listUsers(actor, query);
   }
 
   @GetUserByIdAdminApi()

--- a/src/admin/users/admin-users.service.spec.ts
+++ b/src/admin/users/admin-users.service.spec.ts
@@ -15,8 +15,10 @@ import type { AuthenticatedUserContext } from '../../common/types/auth-user-cont
 import type { PrismaDbClient } from '../../infrastructure/database';
 import { RefreshTokenService } from '../../auth/refresh-token/refresh-token.service';
 import { UserService } from '../../user/user.service';
+import { UserRepository } from '../../user/user.repository';
 import { AdminUsersService } from './admin-users.service';
 import { MANAGEABLE_USER_STATUSES } from './dto/update-user-status.dto';
+import type { ListUsersQueryDto } from './dto/list-users-query.dto';
 
 describe('AdminUsersService', () => {
   let service: AdminUsersService;
@@ -25,6 +27,9 @@ describe('AdminUsersService', () => {
     findMany: jest.Mock;
     update: jest.Mock;
     transaction: jest.Mock;
+  };
+  let userRepository: {
+    findManyPaginated: jest.Mock;
   };
   let refreshTokenService: {
     revokeAllActiveByUserId: jest.Mock;
@@ -67,6 +72,14 @@ describe('AdminUsersService', () => {
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   };
+
+  const defaultQuery: ListUsersQueryDto = {
+    page: 1,
+    limit: 20,
+    sort: 'createdAt',
+    order: 'desc',
+  };
+
   beforeEach(() => {
     userService = {
       findById: jest.fn(),
@@ -78,14 +91,57 @@ describe('AdminUsersService', () => {
           fn(transactionClient),
         ),
     };
+    userRepository = {
+      findManyPaginated: jest.fn(),
+    };
     refreshTokenService = {
       revokeAllActiveByUserId: jest.fn(),
     };
 
     service = new AdminUsersService(
       userService as unknown as UserService,
+      userRepository as unknown as UserRepository,
       refreshTokenService as unknown as RefreshTokenService,
     );
+  });
+
+  describe('listUsers', () => {
+    it('returns paginated user list for admins', async () => {
+      userRepository.findManyPaginated.mockResolvedValue({
+        data: [targetUser],
+        total: 1,
+      });
+
+      const result = await service.listUsers(actorAdmin, defaultQuery);
+
+      expect(userRepository.findManyPaginated).toHaveBeenCalled();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: targetUser.id,
+        email: targetUser.email,
+        firstName: targetUser.firstName,
+        lastName: targetUser.lastName,
+        role: targetUser.role,
+        status: targetUser.status,
+        organizationId: null,
+      });
+      expect(result.meta).toMatchObject({
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        sort: 'createdAt',
+        order: 'desc',
+      });
+    });
+
+    it('throws forbidden when non-admin requests users list', async () => {
+      await expect(
+        service.listUsers(actorStudent, defaultQuery),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(userRepository.findManyPaginated).not.toHaveBeenCalled();
+    });
   });
 
   it('throws when target user does not exist', async () => {
@@ -98,46 +154,6 @@ describe('AdminUsersService', () => {
         MANAGEABLE_USER_STATUSES.ACTIVE,
       ),
     ).rejects.toBeInstanceOf(NotFoundException);
-  });
-
-  it('returns safe users list for admins', async () => {
-    userService.findMany.mockResolvedValue([
-      targetUser,
-      {
-        ...targetUser,
-        id: 'user-2',
-        email: 'user-2@example.com',
-        role: UserRole.COMPANY_OWNER,
-      },
-    ]);
-
-    const result = await service.getUsers(actorAdmin);
-
-    expect(userService.findMany).toHaveBeenCalledWith();
-    expect(result).toEqual([
-      {
-        id: targetUser.id,
-        email: targetUser.email,
-        role: targetUser.role,
-        status: targetUser.status,
-        organizationId: null,
-      },
-      {
-        id: 'user-2',
-        email: 'user-2@example.com',
-        role: UserRole.COMPANY_OWNER,
-        status: targetUser.status,
-        organizationId: null,
-      },
-    ]);
-  });
-
-  it('throws forbidden when non-admin requests users list', async () => {
-    await expect(service.getUsers(actorStudent)).rejects.toBeInstanceOf(
-      ForbiddenException,
-    );
-
-    expect(userService.findMany).not.toHaveBeenCalled();
   });
 
   it('returns safe user by id for admins', async () => {

--- a/src/admin/users/admin-users.service.spec.ts
+++ b/src/admin/users/admin-users.service.spec.ts
@@ -142,6 +142,70 @@ describe('AdminUsersService', () => {
 
       expect(userRepository.findManyPaginated).not.toHaveBeenCalled();
     });
+
+    it('passes q search as OR filter on email, firstName, lastName', async () => {
+      userRepository.findManyPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listUsers(actorAdmin, { ...defaultQuery, q: 'alice' });
+
+      expect(userRepository.findManyPaginated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [
+              { email: { contains: 'alice', mode: 'insensitive' } },
+              { firstName: { contains: 'alice', mode: 'insensitive' } },
+              { lastName: { contains: 'alice', mode: 'insensitive' } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('passes role, status, organizationId as exact filters', async () => {
+      userRepository.findManyPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listUsers(actorAdmin, {
+        ...defaultQuery,
+        role: UserRole.STUDENT,
+        status: UserStatus.ACTIVE,
+        organizationId: 'org-1',
+      });
+
+      expect(userRepository.findManyPaginated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            role: UserRole.STUDENT,
+            status: UserStatus.ACTIVE,
+            organizationId: 'org-1',
+          },
+        }),
+      );
+    });
+
+    it('maps sort=name to firstName then lastName orderBy', async () => {
+      userRepository.findManyPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.listUsers(actorAdmin, {
+        ...defaultQuery,
+        sort: 'name',
+        order: 'asc',
+      });
+
+      expect(userRepository.findManyPaginated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }, { id: 'asc' }],
+        }),
+      );
+    });
   });
 
   it('throws when target user does not exist', async () => {

--- a/src/admin/users/admin-users.service.ts
+++ b/src/admin/users/admin-users.service.ts
@@ -50,13 +50,17 @@ export class AdminUsersService {
       ...(query.organizationId && { organizationId: query.organizationId }),
     };
 
-    const primarySort: Prisma.UserOrderByWithRelationInput =
+    // 'name' is not a DB column — sort by firstName then lastName for full-name ordering
+    const primarySorts: Prisma.UserOrderByWithRelationInput[] =
       query.sort === 'name'
-        ? { firstName: resolveSortOrder(query.order) }
-        : { [query.sort]: resolveSortOrder(query.order) };
+        ? [
+            { firstName: resolveSortOrder(query.order) },
+            { lastName: resolveSortOrder(query.order) },
+          ]
+        : [{ [query.sort]: resolveSortOrder(query.order) }];
 
     const orderBy: Prisma.UserOrderByWithRelationInput[] = [
-      primarySort,
+      ...primarySorts,
       { id: 'asc' },
     ];
     const pagination = resolvePagination(query);

--- a/src/admin/users/admin-users.service.ts
+++ b/src/admin/users/admin-users.service.ts
@@ -3,32 +3,88 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '../../../generated/prisma/client';
 import { UserRole } from '../../../generated/prisma/enums';
 import { ensureAdminRole } from '../../auth/admin-role.helper';
 import type { AuthenticatedUserContext } from '../../common/types/auth-user-context.type';
+import {
+  buildPaginationMeta,
+  resolvePagination,
+  resolveSortOrder,
+} from '../../common/pagination';
 import { RefreshTokenService } from '../../auth/refresh-token/refresh-token.service';
 import { UserService } from '../../user/user.service';
+import { UserRepository } from '../../user/user.repository';
 import {
   MANAGEABLE_USER_STATUSES,
   type ManageableUserStatus,
 } from './dto/update-user-status.dto';
 import { toAuthenticatedUserContext } from '../../user/user.mapper';
+import type { ListUsersQueryDto } from './dto/list-users-query.dto';
+import type { ListUsersResponseDto } from './dto/list-users-response.dto';
 
 @Injectable()
 export class AdminUsersService {
   constructor(
     private readonly userService: UserService,
+    private readonly userRepository: UserRepository,
     private readonly refreshTokenService: RefreshTokenService,
   ) {}
 
-  async getUsers(
+  async listUsers(
     actor: AuthenticatedUserContext,
-  ): Promise<AuthenticatedUserContext[]> {
+    query: ListUsersQueryDto,
+  ): Promise<ListUsersResponseDto> {
     ensureAdminRole(actor.role, 'Only administrators can access users');
 
-    const users = await this.userService.findMany();
+    const where: Prisma.UserWhereInput = {
+      ...(query.q && {
+        OR: [
+          { email: { contains: query.q, mode: 'insensitive' } },
+          { firstName: { contains: query.q, mode: 'insensitive' } },
+          { lastName: { contains: query.q, mode: 'insensitive' } },
+        ],
+      }),
+      ...(query.role && { role: query.role }),
+      ...(query.status && { status: query.status }),
+      ...(query.organizationId && { organizationId: query.organizationId }),
+    };
 
-    return users.map((user) => toAuthenticatedUserContext(user));
+    const primarySort: Prisma.UserOrderByWithRelationInput =
+      query.sort === 'name'
+        ? { firstName: resolveSortOrder(query.order) }
+        : { [query.sort]: resolveSortOrder(query.order) };
+
+    const orderBy: Prisma.UserOrderByWithRelationInput[] = [
+      primarySort,
+      { id: 'asc' },
+    ];
+    const pagination = resolvePagination(query);
+
+    const { data, total } = await this.userRepository.findManyPaginated({
+      where,
+      orderBy,
+      skip: pagination.skip,
+      take: pagination.take,
+    });
+
+    return {
+      data: data.map((user) => ({
+        id: user.id,
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        role: user.role,
+        status: user.status,
+        organizationId: user.organizationId,
+        createdAt: user.createdAt,
+      })),
+      meta: {
+        ...buildPaginationMeta(total, pagination.page, pagination.limit),
+        sort: query.sort,
+        order: query.order,
+      },
+    };
   }
 
   async getUserById(

--- a/src/admin/users/api-docs/admin-users-api-docs.decorators.ts
+++ b/src/admin/users/api-docs/admin-users-api-docs.decorators.ts
@@ -3,8 +3,10 @@ import {
   ApiBearerAuth,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
+  ApiQuery,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { UserRole, UserStatus } from '../../../../generated/prisma/enums';
 import { createApiDecorator } from '../../../infrastructure/api-docs/api-docs-factory';
 import { createPaginationQueryDecorators } from '../../../common/pagination';
 import { AuthenticatedUserDto } from '../../../auth/dto/authenticated-user.dto';
@@ -29,8 +31,36 @@ export const GetUsersAdminApi = () =>
         defaultSort: 'createdAt',
         defaultOrder: 'desc',
       }),
+      ApiQuery({
+        name: 'q',
+        required: false,
+        type: String,
+        description: 'Search by email, first name, or last name.',
+      }),
+      ApiQuery({
+        name: 'role',
+        required: false,
+        enum: UserRole,
+        description: 'Filter by user role.',
+      }),
+      ApiQuery({
+        name: 'status',
+        required: false,
+        enum: UserStatus,
+        description: 'Filter by user status.',
+      }),
+      ApiQuery({
+        name: 'organizationId',
+        required: false,
+        type: String,
+        format: 'uuid',
+        description: 'Filter by organization membership.',
+      }),
     ],
     errors: [
+      ApiBadRequestResponse({
+        description: 'Query parameters are invalid.',
+      }),
       ApiUnauthorizedResponse({
         description: 'Bearer token is missing or invalid.',
       }),

--- a/src/admin/users/api-docs/admin-users-api-docs.decorators.ts
+++ b/src/admin/users/api-docs/admin-users-api-docs.decorators.ts
@@ -1,63 +1,71 @@
-import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiForbiddenResponse,
-  ApiOkResponse,
   ApiNotFoundResponse,
-  ApiOperation,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { AuthenticatedUserDto } from '../../../auth/dto/authenticated-user.dto';
 import { createApiDecorator } from '../../../infrastructure/api-docs/api-docs-factory';
+import { createPaginationQueryDecorators } from '../../../common/pagination';
+import { AuthenticatedUserDto } from '../../../auth/dto/authenticated-user.dto';
+import { ListUsersResponseDto } from '../dto/list-users-response.dto';
 import { UpdateUserStatusDto } from '../dto/update-user-status.dto';
+import { USER_SORT_VALUES } from '../dto/list-users-query.dto';
 
 export const GetUsersAdminApi = () =>
-  applyDecorators(
-    ApiOperation({
-      summary: 'Get users',
-      description:
-        'Allows ADMIN and SUPER_ADMIN accounts to fetch all user accounts.',
-    }),
-    ApiOkResponse({
-      type: AuthenticatedUserDto,
-      isArray: true,
-      description: 'Users were fetched successfully.',
-    }),
-    ApiBearerAuth('access-token'),
-    ApiUnauthorizedResponse({
-      description: 'Bearer token is missing or invalid.',
-    }),
-    ApiForbiddenResponse({
-      description: 'Only administrators can access users.',
-    }),
-  );
+  createApiDecorator({
+    summary: 'List users (admin)',
+    description:
+      'Returns a paginated, filterable, and sortable list of all user accounts for administrators.',
+    successResponse: {
+      status: 200,
+      type: ListUsersResponseDto,
+      description: 'Paginated user list.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ...createPaginationQueryDecorators({
+        sortValues: USER_SORT_VALUES,
+        defaultSort: 'createdAt',
+        defaultOrder: 'desc',
+      }),
+    ],
+    errors: [
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only administrators can access users.',
+      }),
+    ],
+  });
 
 export const GetUserByIdAdminApi = () =>
-  applyDecorators(
-    ApiOperation({
-      summary: 'Get user by id',
-      description:
-        'Allows ADMIN and SUPER_ADMIN accounts to fetch one user account by identifier.',
-    }),
-    ApiOkResponse({
+  createApiDecorator({
+    summary: 'Get user by id',
+    description:
+      'Allows ADMIN and SUPER_ADMIN accounts to fetch one user account by identifier.',
+    successResponse: {
+      status: 200,
       type: AuthenticatedUserDto,
       description: 'User was fetched successfully.',
-    }),
-    ApiBearerAuth('access-token'),
-    ApiBadRequestResponse({
-      description: 'User id must be a valid UUID.',
-    }),
-    ApiUnauthorizedResponse({
-      description: 'Bearer token is missing or invalid.',
-    }),
-    ApiForbiddenResponse({
-      description: 'Only administrators can access users.',
-    }),
-    ApiNotFoundResponse({
-      description: 'Target user was not found.',
-    }),
-  );
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiBadRequestResponse({
+        description: 'User id must be a valid UUID.',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Bearer token is missing or invalid.',
+      }),
+      ApiForbiddenResponse({
+        description: 'Only administrators can access users.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Target user was not found.',
+      }),
+    ],
+  });
 
 export const UpdateUserStatusApi = () =>
   createApiDecorator({

--- a/src/admin/users/dto/admin-user-row.dto.ts
+++ b/src/admin/users/dto/admin-user-row.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole, UserStatus } from '../../../../generated/prisma/enums';
+
+export class AdminUserRowDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ example: 'user@example.com' })
+  email!: string;
+
+  @ApiProperty({ example: 'John' })
+  firstName!: string;
+
+  @ApiProperty({ example: 'Doe' })
+  lastName!: string;
+
+  @ApiProperty({ enum: UserRole })
+  role!: UserRole;
+
+  @ApiProperty({ enum: UserStatus })
+  status!: UserStatus;
+
+  @ApiPropertyOptional({ type: String, format: 'uuid', nullable: true })
+  organizationId!: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt!: Date;
+}

--- a/src/admin/users/dto/list-users-query.dto.ts
+++ b/src/admin/users/dto/list-users-query.dto.ts
@@ -1,0 +1,54 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { UserRole, UserStatus } from '../../../../generated/prisma/enums';
+import {
+  PaginationQueryDto,
+  SORT_ORDER_VALUES,
+  type SortOrder,
+} from '../../../common/pagination';
+
+export const USER_SORT_VALUES = ['createdAt', 'email', 'name'] as const;
+export type UserSortField = (typeof USER_SORT_VALUES)[number];
+
+export class ListUsersQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Search by email or name.',
+    example: 'john',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  q?: string;
+
+  @ApiPropertyOptional({ enum: UserRole })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @ApiPropertyOptional({ enum: UserStatus })
+  @IsOptional()
+  @IsEnum(UserStatus)
+  status?: UserStatus;
+
+  @ApiPropertyOptional({ format: 'uuid' })
+  @IsOptional()
+  @IsUUID()
+  organizationId?: string;
+
+  @ApiPropertyOptional({ enum: USER_SORT_VALUES, default: 'createdAt' })
+  @IsOptional()
+  @IsIn(USER_SORT_VALUES)
+  sort: UserSortField = 'createdAt';
+
+  @ApiPropertyOptional({ enum: SORT_ORDER_VALUES, default: 'desc' })
+  @IsOptional()
+  @IsIn(SORT_ORDER_VALUES)
+  order: SortOrder = 'desc';
+}

--- a/src/admin/users/dto/list-users-query.dto.ts
+++ b/src/admin/users/dto/list-users-query.dto.ts
@@ -1,4 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsEnum,
   IsIn,
@@ -24,6 +25,9 @@ export class ListUsersQueryDto extends PaginationQueryDto {
   })
   @IsOptional()
   @IsString()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @MaxLength(120)
   q?: string;
 

--- a/src/admin/users/dto/list-users-response.dto.ts
+++ b/src/admin/users/dto/list-users-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminListMetaDto } from '../../dto/admin-list-meta.dto';
+import { AdminUserRowDto } from './admin-user-row.dto';
+
+export class ListUsersResponseDto {
+  @ApiProperty({ type: [AdminUserRowDto] })
+  data!: AdminUserRowDto[];
+
+  @ApiProperty({ type: AdminListMetaDto })
+  meta!: AdminListMetaDto;
+}

--- a/src/infrastructure/database/base.repository.ts
+++ b/src/infrastructure/database/base.repository.ts
@@ -126,6 +126,17 @@ export abstract class BaseRepository<
     return this.getDelegate(db).upsert(args);
   }
 
+  async findManyPaginated(
+    args: FindManyArgs<TWhereInput, TOrderByInput, TWhereUniqueInput>,
+    db?: PrismaDbClient,
+  ): Promise<{ data: TModel[]; total: number }> {
+    const [data, total] = await Promise.all([
+      this.findMany(args, db),
+      this.count(args.where, db),
+    ]);
+    return { data, total };
+  }
+
   transaction<T>(
     fn: (client: Prisma.TransactionClient) => Promise<T>,
     options?: PrismaTransactionOptions,

--- a/src/organization/organization.repository.ts
+++ b/src/organization/organization.repository.ts
@@ -8,6 +8,8 @@ import {
 
 type OrganizationDelegate = PrismaClient['organization'];
 
+export type OrgWithMembersCount = Organization & { membersCount: number };
+
 @Injectable()
 export class OrganizationRepository extends BaseRepository<
   Organization,
@@ -24,5 +26,30 @@ export class OrganizationRepository extends BaseRepository<
   protected getDelegate(db?: PrismaDbClient): OrganizationDelegate {
     const client = db ?? this.prisma.client;
     return client.organization;
+  }
+
+  async findManyForAdminPaginated(args: {
+    where?: Prisma.OrganizationWhereInput;
+    orderBy?:
+      | Prisma.OrganizationOrderByWithRelationInput
+      | Prisma.OrganizationOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+  }): Promise<{ data: OrgWithMembersCount[]; total: number }> {
+    const [rows, total] = await Promise.all([
+      this.prisma.client.organization.findMany({
+        ...args,
+        include: { _count: { select: { users: true } } },
+      }),
+      this.prisma.client.organization.count({ where: args.where }),
+    ]);
+
+    return {
+      data: rows.map(({ _count, ...org }) => ({
+        ...org,
+        membersCount: _count.users,
+      })),
+      total,
+    };
   }
 }

--- a/src/organization/organization.repository.ts
+++ b/src/organization/organization.repository.ts
@@ -28,20 +28,24 @@ export class OrganizationRepository extends BaseRepository<
     return client.organization;
   }
 
-  async findManyForAdminPaginated(args: {
-    where?: Prisma.OrganizationWhereInput;
-    orderBy?:
-      | Prisma.OrganizationOrderByWithRelationInput
-      | Prisma.OrganizationOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-  }): Promise<{ data: OrgWithMembersCount[]; total: number }> {
+  async findManyForAdminPaginated(
+    args: {
+      where?: Prisma.OrganizationWhereInput;
+      orderBy?:
+        | Prisma.OrganizationOrderByWithRelationInput
+        | Prisma.OrganizationOrderByWithRelationInput[];
+      skip?: number;
+      take?: number;
+    },
+    db?: PrismaDbClient,
+  ): Promise<{ data: OrgWithMembersCount[]; total: number }> {
+    const client = db ?? this.prisma.client;
     const [rows, total] = await Promise.all([
-      this.prisma.client.organization.findMany({
+      client.organization.findMany({
         ...args,
         include: { _count: { select: { users: true } } },
       }),
-      this.prisma.client.organization.count({ where: args.where }),
+      client.organization.count({ where: args.where }),
     ]);
 
     return {


### PR DESCRIPTION
Implements paginated listing endpoints for the admin directory.

- `GET /api/v1/admin/users` — filterable by role, status, organization; searchable by email or name; sortable by `createdAt`, `email`, `name`
- `GET /api/v1/admin/organizations` — filterable by status, sector; searchable by name or ICO; sortable by `createdAt`, `name`, `status`
- Both return `{ data, meta }` with page, limit, total, totalPages, sort, order

### Implementation notes

- `findManyPaginated` added to `BaseRepository` — runs `findMany` + `count` in parallel
- `findManyForAdminPaginated` added to `OrganizationRepository` — uses Prisma `_count` to compute `membersCount` without a dedicated DB column
- `name` sort for users maps to `firstName → lastName` since there is no combined name column
