### PR TITLE
feat: add Product Owner assignment endpoint for Program B backlog items

### DIFF
--- a/src/programs/program-b/backlog/api-docs/index.ts
+++ b/src/programs/program-b/backlog/api-docs/index.ts
@@ -1,6 +1,7 @@
 export {
   AcceptProgramBBacklogCandidateApi,
   ArchiveProgramBBacklogItemApi,
+  AssignProductOwnerApi,
   CreateProgramBProjectFromCandidateApi,
   CreateProgramBBacklogItemApi,
   DeleteProgramBBacklogItemApi,

--- a/src/programs/program-b/backlog/api-docs/program-b-backlog-api-docs.decorators.ts
+++ b/src/programs/program-b/backlog/api-docs/program-b-backlog-api-docs.decorators.ts
@@ -19,6 +19,7 @@ import { CreateProgramBBacklogItemDto } from '../dto/create-program-b-backlog-it
 import { GetProgramBBacklogResponseDto } from '../dto/get-program-b-backlog-response.dto';
 import { ProgramBCandidateDecisionDto } from '../dto/program-b-candidate-decision.dto';
 import { ProgramBBacklogItemDto } from '../dto/program-b-backlog-item.dto';
+import { AssignProductOwnerDto } from '../dto/assign-product-owner.dto';
 import { UpdateProgramBBacklogItemDto } from '../dto/update-program-b-backlog-item.dto';
 
 export const CreateProgramBBacklogItemApi = () =>
@@ -376,6 +377,44 @@ export const CreateProgramBProjectFromCandidateApi = () =>
       ApiConflictResponse({
         description:
           'Project handoff is allowed only for accepted candidates on non-archived backlog items with an active same-organization product owner.',
+      }),
+    ],
+  });
+
+export const AssignProductOwnerApi = () =>
+  createApiDecorator({
+    summary: 'Assign or reassign Product Owner for a backlog item',
+    description:
+      'Assigns or reassigns the Product Owner for an existing draft or published backlog item. Allowed for company owner (same organization), admin, and super admin.',
+    body: AssignProductOwnerDto,
+    successResponse: {
+      status: 200,
+      type: ProgramBBacklogItemDto,
+      description: 'Product Owner was assigned successfully.',
+    },
+    extraDecorators: [
+      ApiBearerAuth('access-token'),
+      ApiParam({
+        name: 'id',
+        description: 'Backlog item identifier.',
+        format: 'uuid',
+      }),
+    ],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiBadRequestResponse({
+        description: 'Identifier is malformed or request body is invalid.',
+      }),
+      ApiForbiddenResponse({
+        description:
+          'Actor is not allowed to assign Product Owner, or target user is not an active member of the same organization.',
+      }),
+      ApiNotFoundResponse({
+        description: 'Backlog item or target user was not found.',
+      }),
+      ApiConflictResponse({
+        description:
+          'Product Owner cannot be assigned to an archived backlog item.',
       }),
     ],
   });

--- a/src/programs/program-b/backlog/dto/assign-product-owner.dto.ts
+++ b/src/programs/program-b/backlog/dto/assign-product-owner.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class AssignProductOwnerDto {
+  @ApiProperty({
+    description: 'User id to assign as product owner.',
+    format: 'uuid',
+    example: 'd5af8ff2-69e9-4f31-bd0b-a2a226c9ffc5',
+  })
+  @IsUUID()
+  productOwnerUserId!: string;
+}

--- a/src/programs/program-b/backlog/program-b-backlog.controller.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.controller.ts
@@ -22,6 +22,7 @@ import type { AuthenticatedUserContext } from '../../../common/types/auth-user-c
 import {
   AcceptProgramBBacklogCandidateApi,
   ArchiveProgramBBacklogItemApi,
+  AssignProductOwnerApi,
   CreateProgramBProjectFromCandidateApi,
   CreateProgramBBacklogItemApi,
   DeleteProgramBBacklogItemApi,
@@ -36,6 +37,7 @@ import {
   ProgramBProjectDto,
   toProgramBProjectDto,
 } from '../projects/dto/program-b-project.dto';
+import { AssignProductOwnerDto } from './dto/assign-product-owner.dto';
 import { CreateProgramBBacklogItemDto } from './dto/create-program-b-backlog-item.dto';
 import { GetProgramBBacklogQueryDto } from './dto/get-program-b-backlog-query.dto';
 import { GetProgramBBacklogResponseDto } from './dto/get-program-b-backlog-response.dto';
@@ -75,6 +77,19 @@ export class ProgramBBacklogController {
     @GetUserContext() user: AuthenticatedUserContext,
   ): Promise<ProgramBBacklogItemDto> {
     return this.backlogService.update(id, dto, user);
+  }
+
+  @AssignProductOwnerApi()
+  @Patch(':id/product-owner')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.COMPANY_OWNER, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  assignProductOwner(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AssignProductOwnerDto,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<ProgramBBacklogItemDto> {
+    return this.backlogService.assignProductOwner(id, dto, user);
   }
 
   @DeleteProgramBBacklogItemApi()

--- a/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
@@ -44,6 +44,8 @@ jest.mock(
     UserRole: {
       COMPANY_OWNER: 'COMPANY_OWNER',
       COMPANY_EMPLOYEE: 'COMPANY_EMPLOYEE',
+      ADMIN: 'ADMIN',
+      SUPER_ADMIN: 'SUPER_ADMIN',
     },
   }),
   { virtual: true },
@@ -109,6 +111,7 @@ describe('ProgramBBacklogService', () => {
   let userRepository: {
     findOrganizationMember: jest.Mock;
     findActiveOrganizationMember: jest.Mock;
+    findUnique: jest.Mock;
   };
 
   let teamApplicationRepository: {
@@ -138,6 +141,22 @@ describe('ProgramBBacklogService', () => {
     role: UserRole.COMPANY_EMPLOYEE,
     status: 'ACTIVE',
     organizationId: 'org-1',
+  } as const;
+
+  const admin = {
+    id: 'admin-1',
+    email: 'admin@example.com',
+    role: UserRole.ADMIN,
+    status: 'ACTIVE',
+    organizationId: null,
+  } as const;
+
+  const superAdmin = {
+    id: 'super-1',
+    email: 'super@example.com',
+    role: UserRole.SUPER_ADMIN,
+    status: 'ACTIVE',
+    organizationId: null,
   } as const;
 
   const activeOrganization = {
@@ -201,6 +220,7 @@ describe('ProgramBBacklogService', () => {
     userRepository = {
       findOrganizationMember: jest.fn(),
       findActiveOrganizationMember: jest.fn(),
+      findUnique: jest.fn(),
     };
 
     teamApplicationRepository = {
@@ -768,5 +788,218 @@ describe('ProgramBBacklogService', () => {
     );
     expect(backlogRepository.update).not.toHaveBeenCalled();
     expect(result.status).toBe(BacklogItemStatus.ARCHIVED);
+  });
+
+  describe('assignProductOwner', () => {
+    const targetUser = {
+      id: 'po-user-1',
+      organizationId: 'org-1',
+      status: 'ACTIVE',
+    };
+
+    it('company owner assigns product owner on a draft item', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(draftItem)
+        .mockResolvedValueOnce({
+          ...draftItem,
+          productOwnerUserId: 'po-user-1',
+        });
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.assignProductOwner(
+        'item-1',
+        { productOwnerUserId: 'po-user-1' },
+        owner as never,
+      );
+
+      expect(backlogRepository.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'item-1' }),
+        { productOwnerUserId: 'po-user-1' },
+        expect.anything(),
+      );
+      expect(result.productOwnerUserId).toBe('po-user-1');
+    });
+
+    it('company owner assigns product owner on a published item', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(publishedItem)
+        .mockResolvedValueOnce({
+          ...publishedItem,
+          productOwnerUserId: 'po-user-1',
+        });
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.assignProductOwner(
+        'item-1',
+        { productOwnerUserId: 'po-user-1' },
+        owner as never,
+      );
+
+      expect(result.productOwnerUserId).toBe('po-user-1');
+    });
+
+    it('admin assigns product owner without organization membership check', async () => {
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(draftItem)
+        .mockResolvedValueOnce({
+          ...draftItem,
+          productOwnerUserId: 'po-user-1',
+        });
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.assignProductOwner(
+        'item-1',
+        { productOwnerUserId: 'po-user-1' },
+        admin as never,
+      );
+
+      expect(organizationRepository.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('super admin assigns product owner without organization membership check', async () => {
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(draftItem)
+        .mockResolvedValueOnce({
+          ...draftItem,
+          productOwnerUserId: 'po-user-1',
+        });
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.assignProductOwner(
+        'item-1',
+        { productOwnerUserId: 'po-user-1' },
+        superAdmin as never,
+      );
+
+      expect(organizationRepository.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('rejects assignment on archived backlog item with 409', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue({
+        ...draftItem,
+        status: BacklogItemStatus.ARCHIVED,
+      });
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'po-user-1' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('returns 404 when target user does not exist', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue(draftItem);
+      userRepository.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'unknown-user' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects assignment when target user belongs to a different organization', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue(draftItem);
+      userRepository.findUnique.mockResolvedValue({
+        id: 'other-org-user',
+        organizationId: 'org-2',
+        status: 'ACTIVE',
+      });
+      userRepository.findActiveOrganizationMember.mockResolvedValue(null);
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'other-org-user' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('rejects assignment when target user is inactive', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue(draftItem);
+      userRepository.findUnique.mockResolvedValue({
+        id: 'inactive-user',
+        organizationId: 'org-1',
+        status: UserStatus.PENDING,
+      });
+      userRepository.findActiveOrganizationMember.mockResolvedValue(null);
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'inactive-user' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('returns 404 when backlog item does not exist (admin path)', async () => {
+      backlogRepository.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assignProductOwner(
+          'nonexistent-item',
+          { productOwnerUserId: 'po-user-1' },
+          admin as never,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('assertProductOwnerOrAdmin', () => {
+    it('allows the assigned product owner to act', () => {
+      expect(() =>
+        service.assertProductOwnerOrAdmin(
+          { ...owner, id: 'employee-1' } as never,
+          draftItem,
+        ),
+      ).not.toThrow();
+    });
+
+    it('allows admin to act regardless of product owner assignment', () => {
+      expect(() =>
+        service.assertProductOwnerOrAdmin(admin as never, {
+          ...draftItem,
+          productOwnerUserId: 'someone-else',
+        }),
+      ).not.toThrow();
+    });
+
+    it('allows super admin to act regardless of product owner assignment', () => {
+      expect(() =>
+        service.assertProductOwnerOrAdmin(superAdmin as never, {
+          ...draftItem,
+          productOwnerUserId: 'someone-else',
+        }),
+      ).not.toThrow();
+    });
+
+    it('forbids non-PO non-admin users', () => {
+      expect(() =>
+        service.assertProductOwnerOrAdmin(
+          { ...owner, id: 'other-user' } as never,
+          { ...draftItem, productOwnerUserId: 'employee-1' },
+        ),
+      ).toThrow(ForbiddenException);
+    });
   });
 });

--- a/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
@@ -977,9 +977,14 @@ describe('ProgramBBacklogService', () => {
       ).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it('throws ConflictException on race condition when item is archived during transaction', async () => {
+    it('throws ConflictException when item is archived concurrently during transaction', async () => {
       organizationRepository.findUnique.mockResolvedValue(activeOrganization);
-      backlogRepository.findUnique.mockResolvedValue(draftItem);
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(draftItem)
+        .mockResolvedValueOnce({
+          ...draftItem,
+          status: BacklogItemStatus.ARCHIVED,
+        });
       userRepository.findUnique.mockResolvedValue(targetUser);
       userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
       backlogRepository.updateMany.mockResolvedValue({ count: 0 });
@@ -991,6 +996,24 @@ describe('ProgramBBacklogService', () => {
           owner as never,
         ),
       ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws NotFoundException when item is deleted concurrently during transaction', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique
+        .mockResolvedValueOnce(draftItem)
+        .mockResolvedValueOnce(null);
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'po-user-1' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
   });
 

--- a/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
@@ -963,6 +963,35 @@ describe('ProgramBBacklogService', () => {
         ),
       ).rejects.toBeInstanceOf(NotFoundException);
     });
+
+    it('returns 404 when backlog item does not exist (company owner path)', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assignProductOwner(
+          'nonexistent-item',
+          { productOwnerUserId: 'po-user-1' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws ConflictException on race condition when item is archived during transaction', async () => {
+      organizationRepository.findUnique.mockResolvedValue(activeOrganization);
+      backlogRepository.findUnique.mockResolvedValue(draftItem);
+      userRepository.findUnique.mockResolvedValue(targetUser);
+      userRepository.findActiveOrganizationMember.mockResolvedValue(targetUser);
+      backlogRepository.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.assignProductOwner(
+          'item-1',
+          { productOwnerUserId: 'po-user-1' },
+          owner as never,
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
   });
 
   describe('assertProductOwnerOrAdmin', () => {
@@ -970,7 +999,7 @@ describe('ProgramBBacklogService', () => {
       expect(() =>
         service.assertProductOwnerOrAdmin(
           { ...owner, id: 'employee-1' } as never,
-          draftItem,
+          { ...draftItem, productOwnerUserId: 'employee-1' },
         ),
       ).not.toThrow();
     });

--- a/src/programs/program-b/backlog/program-b-backlog.service.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.ts
@@ -219,12 +219,13 @@ export class ProgramBBacklogService {
       );
     }
 
-    await this.ensureAssignableProductOwner(
-      item.organizationId,
-      dto.productOwnerUserId,
-    );
-
     return this.backlogRepository.transaction(async (db) => {
+      await this.ensureAssignableProductOwner(
+        item.organizationId,
+        dto.productOwnerUserId,
+        db,
+      );
+
       const result = await this.backlogRepository.updateMany(
         {
           id: item.id,

--- a/src/programs/program-b/backlog/program-b-backlog.service.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.ts
@@ -15,6 +15,7 @@ import {
   BacklogItemStatus,
   OrganizationStatus,
   ProgramBTeamApplicationStatus,
+  UserRole,
   UserStatus,
 } from '../../../../generated/prisma/enums';
 import { isPrismaUniqueConstraintError } from '../../../common/prisma/prisma-error.utils';
@@ -29,6 +30,7 @@ import { UserRepository } from '../../../user/user.repository';
 import { ProgramBProjectsRepository } from '../projects/program-b-projects.repository';
 import { ProgramBTeamApplicationRepository } from '../team-application/program-b-team-application.repository';
 import type { PrismaDbClient } from '../../../infrastructure/database';
+import { AssignProductOwnerDto } from './dto/assign-product-owner.dto';
 import { CreateProgramBBacklogItemDto } from './dto/create-program-b-backlog-item.dto';
 import { GetProgramBBacklogQueryDto } from './dto/get-program-b-backlog-query.dto';
 import { GetProgramBBacklogResponseDto } from './dto/get-program-b-backlog-response.dto';
@@ -188,6 +190,84 @@ export class ProgramBBacklogService {
 
   async findOne(id: string): Promise<BacklogItem | null> {
     return this.backlogRepository.findUnique({ id });
+  }
+
+  async assignProductOwner(
+    id: string,
+    dto: AssignProductOwnerDto,
+    user: AuthenticatedUserContext,
+  ): Promise<BacklogItem> {
+    const isAdmin =
+      user.role === UserRole.ADMIN || user.role === UserRole.SUPER_ADMIN;
+
+    let item: BacklogItem;
+
+    if (isAdmin) {
+      const found = await this.backlogRepository.findUnique({ id });
+      if (!found) {
+        throw new NotFoundException('Backlog item not found');
+      }
+      item = found;
+    } else {
+      const organization = await this.ensureActiveOrganizationMember(user);
+      item = await this.getItemForOrganizationOrThrow(id, organization.id);
+    }
+
+    if (item.status === BacklogItemStatus.ARCHIVED) {
+      throw new ConflictException(
+        'Product Owner cannot be assigned to an archived backlog item',
+      );
+    }
+
+    await this.ensureAssignableProductOwner(
+      item.organizationId,
+      dto.productOwnerUserId,
+    );
+
+    return this.backlogRepository.transaction(async (db) => {
+      const result = await this.backlogRepository.updateMany(
+        {
+          id: item.id,
+          status: {
+            in: [BacklogItemStatus.DRAFT, BacklogItemStatus.PUBLISHED],
+          },
+        },
+        { productOwnerUserId: dto.productOwnerUserId },
+        db,
+      );
+
+      if (result.count === 0) {
+        throw new ConflictException(
+          'Product Owner cannot be assigned to an archived backlog item',
+        );
+      }
+
+      const updatedItem = await this.backlogRepository.findUnique(
+        { id: item.id },
+        db,
+      );
+
+      if (!updatedItem) {
+        throw new NotFoundException('Backlog item not found');
+      }
+
+      return updatedItem;
+    }, this.backlogLifecycleTransactionOptions);
+  }
+
+  assertProductOwnerOrAdmin(
+    actor: AuthenticatedUserContext,
+    item: BacklogItem,
+  ): void {
+    if (actor.role === UserRole.ADMIN || actor.role === UserRole.SUPER_ADMIN) {
+      return;
+    }
+
+    if (actor.id === item.productOwnerUserId) {
+      return;
+    }
+
+    throw new ForbiddenException();
   }
 
   async listCandidates(backlogItemId: string, user: AuthenticatedUserContext) {
@@ -731,6 +811,33 @@ export class ProgramBBacklogService {
     if (!productOwner) {
       throw new BadRequestException(
         'Product owner must be a member of the same organization',
+      );
+    }
+  }
+
+  private async ensureAssignableProductOwner(
+    organizationId: string,
+    productOwnerUserId: string,
+    db?: PrismaDbClient,
+  ): Promise<void> {
+    const user = await this.userRepository.findUnique(
+      { id: productOwnerUserId },
+      db,
+    );
+
+    if (!user) {
+      throw new NotFoundException('Target user not found');
+    }
+
+    const member = await this.userRepository.findActiveOrganizationMember(
+      organizationId,
+      productOwnerUserId,
+      db,
+    );
+
+    if (!member) {
+      throw new ForbiddenException(
+        'Target user must be an active member of the same organization',
       );
     }
   }

--- a/src/programs/program-b/backlog/program-b-backlog.service.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.ts
@@ -237,16 +237,19 @@ export class ProgramBBacklogService {
         db,
       );
 
-      if (result.count === 0) {
-        throw new ConflictException(
-          'Product Owner cannot be assigned to an archived backlog item',
-        );
-      }
-
       const updatedItem = await this.backlogRepository.findUnique(
         { id: item.id },
         db,
       );
+
+      if (result.count === 0) {
+        if (!updatedItem) {
+          throw new NotFoundException('Backlog item not found');
+        }
+        throw new ConflictException(
+          'Product Owner cannot be assigned to an archived backlog item',
+        );
+      }
 
       if (!updatedItem) {
         throw new NotFoundException('Backlog item not found');


### PR DESCRIPTION
### Summary

- Adds `PATCH /api/v1/program-b/backlog/:id/product-owner` endpoint to assign or reassign a Product Owner on a draft or published backlog item
- Company owners can assign any active member of their own organization; admins and super admins can assign to any backlog item regardless of org
- Archived backlog items reject assignment with 409
- Target user must exist in the system (404) and be an active member of the backlog item's organization (403)
- Adds reusable `assertProductOwnerOrAdmin` helper on the service for guarding future PO-only actions

### Changes

- `dto/assign-product-owner.dto.ts` — new DTO with `productOwnerUserId` UUID field
- `program-b-backlog.service.ts` — `assignProductOwner`, `assertProductOwnerOrAdmin` (public), `ensureAssignableProductOwner` (private)
- `program-b-backlog.controller.ts` — new `PATCH :id/product-owner` route with `COMPANY_OWNER | ADMIN | SUPER_ADMIN` role guard
- `api-docs/` — `AssignProductOwnerApi` Swagger decorator
