### PR TITLE
feat(program-a): add internal review list and milestones

### DIFF
--- a/prisma/migrations/20260522205001_add_program_a_project_tracking/migration.sql
+++ b/prisma/migrations/20260522205001_add_program_a_project_tracking/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "ProgramAMilestoneStatus" AS ENUM ('PLANNED', 'IN_PROGRESS', 'DONE', 'BLOCKED');
+
+-- CreateTable
+CREATE TABLE "ProgramAMilestone" (
+    "id" TEXT NOT NULL,
+    "applicationId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "dueAt" TIMESTAMP(3),
+    "status" "ProgramAMilestoneStatus" NOT NULL DEFAULT 'PLANNED',
+    "progressNote" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProgramAMilestone_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProgramAMilestone_applicationId_createdAt_idx" ON "ProgramAMilestone"("applicationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ProgramAMilestone_applicationId_status_idx" ON "ProgramAMilestone"("applicationId", "status");
+
+-- AddForeignKey
+ALTER TABLE "ProgramAMilestone" ADD CONSTRAINT "ProgramAMilestone_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,13 @@ enum NeedsInfoItemStatus {
   RESOLVED
 }
 
+enum ProgramAMilestoneStatus {
+  PLANNED
+  IN_PROGRESS
+  DONE
+  BLOCKED
+}
+
 enum ProgramBProjectStatus {
   ACTIVE
   BLOCKED
@@ -394,8 +401,9 @@ model Application {
   mentorAssignedById String?
   mentorAssignedBy   User?                    @relation("ApplicationMentorAssignedBy", fields: [mentorAssignedById], references: [id], onDelete: SetNull)
 
-  mentorshipNotes  ProgramAMentorshipNote[]
-  programBProjects ProgramBProject[]
+  mentorshipNotes    ProgramAMentorshipNote[]
+  programAMilestones ProgramAMilestone[]
+  programBProjects   ProgramBProject[]
 
   status      ApplicationStatus @default(DRAFT)
   submittedAt DateTime?
@@ -469,6 +477,26 @@ model ProgramAMentorshipNote {
 
   @@index([applicationId, createdAt, id])
   @@index([authorId, createdAt])
+}
+
+model ProgramAMilestone {
+  id String @id @default(uuid())
+
+  applicationId String
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+
+  title       String
+  description String?
+  dueAt       DateTime?
+  status      ProgramAMilestoneStatus @default(PLANNED)
+
+  progressNote String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([applicationId, createdAt])
+  @@index([applicationId, status])
 }
 
 model EligibilitySignal {

--- a/src/applications/admin-applications.controller.spec.ts
+++ b/src/applications/admin-applications.controller.spec.ts
@@ -12,6 +12,8 @@ jest.mock('../auth/guards/roles.guard', () => ({
 
 import { AdminApplicationsController } from './admin-applications.controller';
 import { ApplicationsService } from './applications.service';
+import { ROLES_KEY } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../../generated/prisma/enums';
 
 describe('AdminApplicationsController', () => {
   let controller: AdminApplicationsController;
@@ -43,6 +45,44 @@ describe('AdminApplicationsController', () => {
     controller = new AdminApplicationsController(
       applicationsService as unknown as ApplicationsService,
     );
+  });
+
+  it('restricts controller-wide roles to reviewer-side users', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, AdminApplicationsController)).toEqual(
+      [UserRole.EVALUATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    );
+  });
+
+  it('allows mentors only on milestone endpoints', () => {
+    const listProgramAMilestones: object = Object.getOwnPropertyDescriptor(
+      AdminApplicationsController.prototype,
+      'listProgramAMilestones',
+    )!.value as object;
+    const createProgramAMilestone: object = Object.getOwnPropertyDescriptor(
+      AdminApplicationsController.prototype,
+      'createProgramAMilestone',
+    )!.value as object;
+    const updateProgramAMilestone: object = Object.getOwnPropertyDescriptor(
+      AdminApplicationsController.prototype,
+      'updateProgramAMilestone',
+    )!.value as object;
+
+    expect(Reflect.getMetadata(ROLES_KEY, listProgramAMilestones)).toEqual([
+      UserRole.EVALUATOR,
+      UserRole.ADMIN,
+      UserRole.SUPER_ADMIN,
+      UserRole.MENTOR,
+    ]);
+    expect(Reflect.getMetadata(ROLES_KEY, createProgramAMilestone)).toEqual([
+      UserRole.ADMIN,
+      UserRole.SUPER_ADMIN,
+      UserRole.MENTOR,
+    ]);
+    expect(Reflect.getMetadata(ROLES_KEY, updateProgramAMilestone)).toEqual([
+      UserRole.ADMIN,
+      UserRole.SUPER_ADMIN,
+      UserRole.MENTOR,
+    ]);
   });
 
   it('delegates formal verification with optional note', async () => {

--- a/src/applications/admin-applications.controller.ts
+++ b/src/applications/admin-applications.controller.ts
@@ -40,12 +40,7 @@ import { InternalProgramAApplicationDto } from './dto/internal-program-a-applica
 @ApiTags('Admin')
 @Controller('admin/applications')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(
-  UserRole.EVALUATOR,
-  UserRole.ADMIN,
-  UserRole.SUPER_ADMIN,
-  UserRole.MENTOR,
-)
+@Roles(UserRole.EVALUATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
 export class AdminApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
   @Get('program-a')
@@ -55,6 +50,12 @@ export class AdminApplicationsController {
     return this.applicationsService.listInternalProgramAApplications(user);
   }
 
+  @Roles(
+    UserRole.EVALUATOR,
+    UserRole.ADMIN,
+    UserRole.SUPER_ADMIN,
+    UserRole.MENTOR,
+  )
   @Get(':id/program-a-milestones')
   listProgramAMilestones(
     @Param('id', ParseUUIDPipe) id: string,
@@ -63,6 +64,7 @@ export class AdminApplicationsController {
     return this.applicationsService.listProgramAMilestones(id, user);
   }
 
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.MENTOR)
   @Post(':id/program-a-milestones')
   createProgramAMilestone(
     @Param('id', ParseUUIDPipe) id: string,
@@ -72,6 +74,7 @@ export class AdminApplicationsController {
     return this.applicationsService.createProgramAMilestone(id, user, dto);
   }
 
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.MENTOR)
   @Patch(':id/program-a-milestones/:milestoneId')
   updateProgramAMilestone(
     @Param('id', ParseUUIDPipe) id: string,

--- a/src/applications/admin-applications.controller.ts
+++ b/src/applications/admin-applications.controller.ts
@@ -1,10 +1,12 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -29,14 +31,61 @@ import {
 import { ApplicationsService } from './applications.service';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
 import { ApplicationLifecycleTransitionDto } from './dto/application-lifecycle-transition.dto';
+import { CreateProgramAMilestoneDto } from './dto/create-program-a-milestone.dto';
 import { OptionalApplicationTransitionNoteDto } from './dto/optional-application-transition-note.dto';
+import { ProgramAMilestoneDto } from './dto/program-a-milestone.dto';
+import { UpdateProgramAMilestoneDto } from './dto/update-program-a-milestone.dto';
+import { InternalProgramAApplicationDto } from './dto/internal-program-a-application.dto';
 
 @ApiTags('Admin')
 @Controller('admin/applications')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(UserRole.EVALUATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@Roles(
+  UserRole.EVALUATOR,
+  UserRole.ADMIN,
+  UserRole.SUPER_ADMIN,
+  UserRole.MENTOR,
+)
 export class AdminApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
+  @Get('program-a')
+  listProgramAApplications(
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<InternalProgramAApplicationDto[]> {
+    return this.applicationsService.listInternalProgramAApplications(user);
+  }
+
+  @Get(':id/program-a-milestones')
+  listProgramAMilestones(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<ProgramAMilestoneDto[]> {
+    return this.applicationsService.listProgramAMilestones(id, user);
+  }
+
+  @Post(':id/program-a-milestones')
+  createProgramAMilestone(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: CreateProgramAMilestoneDto,
+  ): Promise<ProgramAMilestoneDto> {
+    return this.applicationsService.createProgramAMilestone(id, user, dto);
+  }
+
+  @Patch(':id/program-a-milestones/:milestoneId')
+  updateProgramAMilestone(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('milestoneId', ParseUUIDPipe) milestoneId: string,
+    @GetUserContext() user: AuthenticatedUserContext,
+    @Body() dto: UpdateProgramAMilestoneDto,
+  ): Promise<ProgramAMilestoneDto> {
+    return this.applicationsService.updateProgramAMilestone(
+      id,
+      milestoneId,
+      user,
+      dto,
+    );
+  }
 
   @FormalVerifyApplicationApi()
   @HttpCode(HttpStatus.OK)

--- a/src/applications/applications.module.ts
+++ b/src/applications/applications.module.ts
@@ -20,6 +20,7 @@ import { UserRepository } from '../user/user.repository';
 import { ApplicationSectionsRulesService } from './rules/application-sections-rules.service';
 import { ApplicationSectionsService } from './application-sections.service';
 import { ApplicationEvaluationsRepository } from './application-evaluations.repository';
+import { ProgramAMilestonesRepository } from './program-a-milestones.repository';
 
 @Module({
   imports: [AuthModule, TeamModule, FilesModule, EligibilitySignalsModule],
@@ -36,6 +37,7 @@ import { ApplicationEvaluationsRepository } from './application-evaluations.repo
     ApplicationDocumentsRepository,
     CallsRepository,
     ProgramAMentorshipRepository,
+    ProgramAMilestonesRepository,
     UserRepository,
     ApplicationRulesService,
     ApplicationSectionsRulesService,

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { Application, Prisma } from '../../generated/prisma/client';
-import { ApplicationStatus } from '../../generated/prisma/enums';
+import { ApplicationStatus, ProgramType } from '../../generated/prisma/enums';
 import { BaseRepository, PrismaDbClient } from '../infrastructure/database';
 import { PrismaService } from '../infrastructure/database/prisma.service';
 
@@ -60,6 +60,63 @@ export class ApplicationsRepository extends BaseRepository<
     return (db ?? this.prisma.client).application.findUnique({
       where: { id },
       select: this.applicationEligibilitySelect(),
+    });
+  }
+
+  listInternalProgramAApplications(db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).application.findMany({
+      where: {
+        call: {
+          type: ProgramType.PROGRAM_A,
+        },
+        status: {
+          not: ApplicationStatus.DRAFT,
+        },
+      },
+      orderBy: [
+        {
+          submittedAt: 'desc',
+        },
+        {
+          createdAt: 'desc',
+        },
+      ],
+      select: {
+        id: true,
+        status: true,
+        submittedAt: true,
+        decidedAt: true,
+        mentorUserId: true,
+        mentorAssignedAt: true,
+        mentorAssignedById: true,
+        createdAt: true,
+        updatedAt: true,
+        team: {
+          select: {
+            id: true,
+            name: true,
+            leaderId: true,
+          },
+        },
+        call: {
+          select: {
+            id: true,
+            title: true,
+            type: true,
+            status: true,
+            opensAt: true,
+            closesAt: true,
+          },
+        },
+        eligibilitySignals: {
+          select: {
+            id: true,
+            code: true,
+            passed: true,
+            reason: true,
+          },
+        },
+      },
     });
   }
 

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -52,6 +52,7 @@ import {
   ApplicationStatus,
   CallStatus,
   DocumentType,
+  ProgramAMilestoneStatus,
   ProgramType,
   UploadStatus,
   UserRole,
@@ -71,6 +72,7 @@ describe('ApplicationsService', () => {
     assignMentor: jest.Mock;
     updateStatusIfCurrent: jest.Mock;
     updateDecisionIfCurrent: jest.Mock;
+    listInternalProgramAApplications: jest.Mock;
   };
   let applicationDocumentsRepository: {
     deactivateActiveBySlot: jest.Mock;
@@ -102,6 +104,12 @@ describe('ApplicationsService', () => {
   let programAMentorshipRepository: {
     createNote: jest.Mock;
     listNotes: jest.Mock;
+  };
+  let programAMilestonesRepository: {
+    createMilestone: jest.Mock;
+    listByApplication: jest.Mock;
+    findByIdForApplication: jest.Mock;
+    updateMilestone: jest.Mock;
   };
   let userRepository: {
     findUnique: jest.Mock;
@@ -280,6 +288,7 @@ describe('ApplicationsService', () => {
       assignMentor: jest.fn(),
       updateStatusIfCurrent: jest.fn(),
       updateDecisionIfCurrent: jest.fn(),
+      listInternalProgramAApplications: jest.fn(),
       transaction: jest.fn((fn: (db: never) => Promise<unknown>) =>
         fn({ tx: 'db-client' } as never),
       ),
@@ -325,6 +334,13 @@ describe('ApplicationsService', () => {
       listNotes: jest.fn(),
     };
 
+    programAMilestonesRepository = {
+      createMilestone: jest.fn(),
+      listByApplication: jest.fn(),
+      findByIdForApplication: jest.fn(),
+      updateMilestone: jest.fn(),
+    };
+
     userRepository = {
       findUnique: jest.fn(),
     };
@@ -361,6 +377,7 @@ describe('ApplicationsService', () => {
       needsInfoRepository as never,
       eligibilitySignalsService as never,
       programAMentorshipRepository as never,
+      programAMilestonesRepository as never,
       userRepository as never,
       queueService as never,
     );
@@ -632,6 +649,111 @@ describe('ApplicationsService', () => {
         role: UserRole.STUDENT,
       } as never),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  describe('internal Program A application list', () => {
+    it('lists internal Program A applications for reviewer-side user', async () => {
+      applicationsRepository.listInternalProgramAApplications.mockResolvedValue(
+        [
+          {
+            id: 'application-1',
+            status: ApplicationStatus.SUBMITTED,
+            submittedAt: new Date('2026-05-01T10:00:00.000Z'),
+            decidedAt: null,
+            mentorUserId: 'mentor-1',
+            mentorAssignedAt: new Date('2026-05-02T10:00:00.000Z'),
+            mentorAssignedById: 'admin-1',
+            createdAt: new Date('2026-04-30T10:00:00.000Z'),
+            updatedAt: new Date('2026-05-02T10:00:00.000Z'),
+            team: {
+              id: 'team-1',
+              name: 'Test Team',
+              leaderId: 'user-1',
+            },
+            call: {
+              id: 'call-1',
+              title: 'Program A Call',
+              type: ProgramType.PROGRAM_A,
+              status: CallStatus.OPEN,
+              opensAt: null,
+              closesAt: null,
+            },
+            eligibilitySignals: [
+              {
+                id: 'signal-1',
+                code: 'TEAM_SIZE_MIN',
+                passed: true,
+                reason: null,
+              },
+              {
+                id: 'signal-2',
+                code: 'ACADEMIC_EVIDENCE_REQUIRED',
+                passed: false,
+                reason: 'Missing academic evidence',
+              },
+            ],
+          },
+        ],
+      );
+
+      const result = await service.listInternalProgramAApplications({
+        id: 'evaluator-1',
+        email: 'evaluator@example.com',
+        role: UserRole.EVALUATOR,
+      } as never);
+
+      expect(
+        applicationsRepository.listInternalProgramAApplications,
+      ).toHaveBeenCalledTimes(1);
+
+      expect(result).toEqual([
+        {
+          id: 'application-1',
+          status: ApplicationStatus.SUBMITTED,
+          submittedAt: new Date('2026-05-01T10:00:00.000Z'),
+          decidedAt: null,
+          team: {
+            id: 'team-1',
+            name: 'Test Team',
+            leaderId: 'user-1',
+          },
+          call: {
+            id: 'call-1',
+            title: 'Program A Call',
+            type: ProgramType.PROGRAM_A,
+            status: CallStatus.OPEN,
+            opensAt: null,
+            closesAt: null,
+          },
+          mentorAssignment: {
+            mentorUserId: 'mentor-1',
+            mentorAssignedAt: new Date('2026-05-02T10:00:00.000Z'),
+            mentorAssignedById: 'admin-1',
+          },
+          eligibilitySignalSummary: {
+            total: 2,
+            passed: 1,
+            failed: 1,
+          },
+          createdAt: new Date('2026-04-30T10:00:00.000Z'),
+          updatedAt: new Date('2026-05-02T10:00:00.000Z'),
+        },
+      ]);
+    });
+
+    it('forbids student from listing internal Program A applications', async () => {
+      await expect(
+        service.listInternalProgramAApplications({
+          id: 'user-1',
+          email: 'lead@example.com',
+          role: UserRole.STUDENT,
+        } as never),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(
+        applicationsRepository.listInternalProgramAApplications,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   it('submits a complete draft application and locks the team', async () => {
@@ -1298,6 +1420,215 @@ describe('ApplicationsService', () => {
       'application-1',
     );
     expect(result.map((note) => note.id)).toEqual(['note-1', 'note-2']);
+  });
+
+  describe('Program A milestones', () => {
+    const approvedProgramAApplication = {
+      ...workflowApplication,
+      status: ApplicationStatus.APPROVED,
+      mentorUserId: 'mentor-1',
+    };
+
+    const milestone = {
+      id: 'milestone-1',
+      applicationId: 'application-1',
+      title: 'Build MVP prototype',
+      description: 'Prepare a working MVP version for internal demo.',
+      dueAt: new Date('2026-06-30T23:59:59.000Z'),
+      status: ProgramAMilestoneStatus.PLANNED,
+      progressNote: 'Initial planning completed.',
+      createdAt: new Date('2026-06-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+    };
+
+    it('allows admin to create Program A milestone for approved application', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.createMilestone.mockResolvedValue(milestone);
+
+      const result = await service.createProgramAMilestone(
+        'application-1',
+        {
+          id: 'admin-1',
+          email: 'admin@example.com',
+          role: UserRole.ADMIN,
+        } as never,
+        {
+          title: 'Build MVP prototype',
+          description: 'Prepare a working MVP version for internal demo.',
+          dueAt: '2026-06-30T23:59:59.000Z',
+          status: ProgramAMilestoneStatus.PLANNED,
+          progressNote: 'Initial planning completed.',
+        },
+      );
+
+      expect(programAMilestonesRepository.createMilestone).toHaveBeenCalledWith(
+        {
+          applicationId: 'application-1',
+          title: 'Build MVP prototype',
+          description: 'Prepare a working MVP version for internal demo.',
+          dueAt: new Date('2026-06-30T23:59:59.000Z'),
+          status: ProgramAMilestoneStatus.PLANNED,
+          progressNote: 'Initial planning completed.',
+        },
+        { tx: 'db-client' },
+      );
+      expect(result.id).toBe('milestone-1');
+      expect(result.status).toBe(ProgramAMilestoneStatus.PLANNED);
+    });
+
+    it('allows assigned mentor to create Program A milestone', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.createMilestone.mockResolvedValue(milestone);
+
+      const result = await service.createProgramAMilestone(
+        'application-1',
+        {
+          id: 'mentor-1',
+          email: 'mentor@example.com',
+          role: UserRole.MENTOR,
+        } as never,
+        {
+          title: 'Build MVP prototype',
+        },
+      );
+
+      expect(result.id).toBe('milestone-1');
+      expect(programAMilestonesRepository.createMilestone).toHaveBeenCalled();
+    });
+
+    it('forbids student from creating Program A milestone', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+
+      await expect(
+        service.createProgramAMilestone(
+          'application-1',
+          {
+            id: 'user-1',
+            email: 'lead@example.com',
+            role: UserRole.STUDENT,
+          } as never,
+          {
+            title: 'Build MVP prototype',
+          },
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('rejects milestone creation before application is approved', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue({
+        ...workflowApplication,
+        status: ApplicationStatus.EVALUATING,
+        mentorUserId: 'mentor-1',
+      });
+
+      await expect(
+        service.createProgramAMilestone(
+          'application-1',
+          {
+            id: 'admin-1',
+            email: 'admin@example.com',
+            role: UserRole.ADMIN,
+          } as never,
+          {
+            title: 'Build MVP prototype',
+          },
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('lists Program A milestones for reviewer-side user', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.listByApplication.mockResolvedValue([
+        milestone,
+      ]);
+
+      const result = await service.listProgramAMilestones('application-1', {
+        id: 'evaluator-1',
+        email: 'evaluator@example.com',
+        role: UserRole.EVALUATOR,
+      } as never);
+
+      expect(
+        programAMilestonesRepository.listByApplication,
+      ).toHaveBeenCalledWith('application-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('milestone-1');
+    });
+
+    it('updates Program A milestone', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.findByIdForApplication.mockResolvedValue(
+        milestone,
+      );
+      programAMilestonesRepository.updateMilestone.mockResolvedValue({
+        ...milestone,
+        status: ProgramAMilestoneStatus.IN_PROGRESS,
+        progressNote: 'Backend integration started.',
+      });
+
+      const result = await service.updateProgramAMilestone(
+        'application-1',
+        'milestone-1',
+        {
+          id: 'admin-1',
+          email: 'admin@example.com',
+          role: UserRole.ADMIN,
+        } as never,
+        {
+          status: ProgramAMilestoneStatus.IN_PROGRESS,
+          progressNote: 'Backend integration started.',
+        },
+      );
+
+      expect(
+        programAMilestonesRepository.findByIdForApplication,
+      ).toHaveBeenCalledWith('application-1', 'milestone-1', {
+        tx: 'db-client',
+      });
+      expect(programAMilestonesRepository.updateMilestone).toHaveBeenCalledWith(
+        'milestone-1',
+        {
+          status: ProgramAMilestoneStatus.IN_PROGRESS,
+          progressNote: 'Backend integration started.',
+        },
+        { tx: 'db-client' },
+      );
+      expect(result.status).toBe(ProgramAMilestoneStatus.IN_PROGRESS);
+    });
+
+    it('throws not found when updating missing Program A milestone', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.findByIdForApplication.mockResolvedValue(
+        null,
+      );
+
+      await expect(
+        service.updateProgramAMilestone(
+          'application-1',
+          'missing-milestone',
+          {
+            id: 'admin-1',
+            email: 'admin@example.com',
+            role: UserRole.ADMIN,
+          } as never,
+          {
+            status: ProgramAMilestoneStatus.DONE,
+          },
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 
   it('starts onboarding for approved Program A application', async () => {

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -1500,6 +1500,30 @@ describe('ApplicationsService', () => {
       expect(programAMilestonesRepository.createMilestone).toHaveBeenCalled();
     });
 
+    it('rejects whitespace-only milestone title on create', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+
+      await expect(
+        service.createProgramAMilestone(
+          'application-1',
+          {
+            id: 'admin-1',
+            email: 'admin@example.com',
+            role: UserRole.ADMIN,
+          } as never,
+          {
+            title: '   ',
+          },
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(
+        programAMilestonesRepository.createMilestone,
+      ).not.toHaveBeenCalled();
+    });
+
     it('forbids student from creating Program A milestone', async () => {
       applicationsRepository.findByIdForWorkflow.mockResolvedValue(
         approvedProgramAApplication,
@@ -1604,6 +1628,34 @@ describe('ApplicationsService', () => {
         { tx: 'db-client' },
       );
       expect(result.status).toBe(ProgramAMilestoneStatus.IN_PROGRESS);
+    });
+
+    it('rejects whitespace-only milestone title on update', async () => {
+      applicationsRepository.findByIdForWorkflow.mockResolvedValue(
+        approvedProgramAApplication,
+      );
+      programAMilestonesRepository.findByIdForApplication.mockResolvedValue(
+        milestone,
+      );
+
+      await expect(
+        service.updateProgramAMilestone(
+          'application-1',
+          'milestone-1',
+          {
+            id: 'admin-1',
+            email: 'admin@example.com',
+            role: UserRole.ADMIN,
+          } as never,
+          {
+            title: '   ',
+          },
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(
+        programAMilestonesRepository.updateMilestone,
+      ).not.toHaveBeenCalled();
     });
 
     it('throws not found when updating missing Program A milestone', async () => {

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -1019,10 +1019,15 @@ export class ApplicationsService {
       this.ensureProgramATrackingAccess(application, user);
       this.ensureArchivedApplicationIsReadOnlyForNonAdmin(application, user);
 
+      const title = dto.title.trim();
+      if (title.length === 0) {
+        throw new BadRequestException('Milestone title cannot be empty');
+      }
+
       const milestone = await this.programAMilestonesRepository.createMilestone(
         {
           applicationId: application.id,
-          title: dto.title.trim(),
+          title,
           description: dto.description?.trim() || null,
           dueAt: dto.dueAt ? new Date(dto.dueAt) : null,
           status: dto.status,
@@ -1080,10 +1085,18 @@ export class ApplicationsService {
         throw new NotFoundException('Program A milestone not found');
       }
 
+      const trimmedTitle = dto.title?.trim();
+      if (
+        dto.title !== undefined &&
+        (!trimmedTitle || trimmedTitle.length === 0)
+      ) {
+        throw new BadRequestException('Milestone title cannot be empty');
+      }
+
       const milestone = await this.programAMilestonesRepository.updateMilestone(
         existing.id,
         {
-          ...(dto.title !== undefined ? { title: dto.title.trim() } : {}),
+          ...(dto.title !== undefined ? { title: trimmedTitle! } : {}),
           ...(dto.description !== undefined
             ? { description: dto.description?.trim() || null }
             : {}),

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -40,6 +40,10 @@ import { ApplicationStatusEventDto } from './dto/application-status-event.dto';
 import { AssignMentorDto } from './dto/assign-mentor.dto';
 import { AttachApplicationDocumentDto } from './dto/attach-application-document.dto';
 import { CreateApplicationDto } from './dto/create-application.dto';
+import { CreateProgramAMilestoneDto } from './dto/create-program-a-milestone.dto';
+import { UpdateProgramAMilestoneDto } from './dto/update-program-a-milestone.dto';
+import { ProgramAMilestoneDto } from './dto/program-a-milestone.dto';
+import { InternalProgramAApplicationDto } from './dto/internal-program-a-application.dto';
 import {
   ApplicationDecision,
   CreateApplicationDecisionDto,
@@ -72,6 +76,10 @@ import {
   ProgramAMentorshipNoteWithAuthor,
   ProgramAMentorshipRepository,
 } from './program-a-mentorship.repository';
+import {
+  ProgramAMilestoneWithApplication,
+  ProgramAMilestonesRepository,
+} from './program-a-milestones.repository';
 import { CreateApplicationEvaluationDto } from './dto/create-application-evaluation.dto';
 import { PROGRAM_A_SECTION_KEYS } from './program-a/program-a-application-sections.contract';
 
@@ -123,9 +131,27 @@ export class ApplicationsService {
     private readonly needsInfoRepository: NeedsInfoRepository,
     private readonly eligibilitySignalsService: EligibilitySignalsService,
     private readonly programAMentorshipRepository: ProgramAMentorshipRepository,
+    private readonly programAMilestonesRepository: ProgramAMilestonesRepository,
     private readonly userRepository: UserRepository,
     private readonly queueService: QueueService,
   ) {}
+
+  async listInternalProgramAApplications(
+    user: AuthenticatedUserContext,
+  ): Promise<InternalProgramAApplicationDto[]> {
+    if (!this.isReviewerSideUser(user)) {
+      throw new ForbiddenException(
+        'Only reviewer-side users can list internal Program A applications',
+      );
+    }
+
+    const applications =
+      await this.applicationsRepository.listInternalProgramAApplications();
+
+    return applications.map((application) =>
+      this.toInternalProgramAApplicationDto(application),
+    );
+  }
 
   async createDraft(
     user: AuthenticatedUserContext,
@@ -978,6 +1004,104 @@ export class ApplicationsService {
     return notes.map((note) => this.toProgramAMentorshipNoteDto(note));
   }
 
+  async createProgramAMilestone(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+    dto: CreateProgramAMilestoneDto,
+  ): Promise<ProgramAMilestoneDto> {
+    return this.applicationsRepository.transaction(async (db) => {
+      const application = await this.loadWorkflowApplicationOrThrow(
+        applicationId,
+        db,
+      );
+
+      this.ensureProgramATrackingWorkflow(application);
+      this.ensureProgramATrackingAccess(application, user);
+      this.ensureArchivedApplicationIsReadOnlyForNonAdmin(application, user);
+
+      const milestone = await this.programAMilestonesRepository.createMilestone(
+        {
+          applicationId: application.id,
+          title: dto.title.trim(),
+          description: dto.description?.trim() || null,
+          dueAt: dto.dueAt ? new Date(dto.dueAt) : null,
+          status: dto.status,
+          progressNote: dto.progressNote?.trim() || null,
+        },
+        db,
+      );
+
+      return this.toProgramAMilestoneDto(milestone);
+    });
+  }
+
+  async listProgramAMilestones(
+    applicationId: string,
+    user: AuthenticatedUserContext,
+  ): Promise<ProgramAMilestoneDto[]> {
+    const application =
+      await this.loadWorkflowApplicationOrThrow(applicationId);
+
+    this.ensureProgramATrackingWorkflow(application);
+    this.ensureProgramATrackingReadAccess(application, user);
+
+    const milestones =
+      await this.programAMilestonesRepository.listByApplication(application.id);
+
+    return milestones.map((milestone) =>
+      this.toProgramAMilestoneDto(milestone),
+    );
+  }
+
+  async updateProgramAMilestone(
+    applicationId: string,
+    milestoneId: string,
+    user: AuthenticatedUserContext,
+    dto: UpdateProgramAMilestoneDto,
+  ): Promise<ProgramAMilestoneDto> {
+    return this.applicationsRepository.transaction(async (db) => {
+      const application = await this.loadWorkflowApplicationOrThrow(
+        applicationId,
+        db,
+      );
+
+      this.ensureProgramATrackingWorkflow(application);
+      this.ensureProgramATrackingAccess(application, user);
+      this.ensureArchivedApplicationIsReadOnlyForNonAdmin(application, user);
+
+      const existing =
+        await this.programAMilestonesRepository.findByIdForApplication(
+          application.id,
+          milestoneId,
+          db,
+        );
+
+      if (!existing) {
+        throw new NotFoundException('Program A milestone not found');
+      }
+
+      const milestone = await this.programAMilestonesRepository.updateMilestone(
+        existing.id,
+        {
+          ...(dto.title !== undefined ? { title: dto.title.trim() } : {}),
+          ...(dto.description !== undefined
+            ? { description: dto.description?.trim() || null }
+            : {}),
+          ...(dto.dueAt !== undefined
+            ? { dueAt: dto.dueAt ? new Date(dto.dueAt) : null }
+            : {}),
+          ...(dto.status !== undefined ? { status: dto.status } : {}),
+          ...(dto.progressNote !== undefined
+            ? { progressNote: dto.progressNote?.trim() || null }
+            : {}),
+        },
+        db,
+      );
+
+      return this.toProgramAMilestoneDto(milestone);
+    });
+  }
+
   async startOnboarding(
     applicationId: string,
     user: AuthenticatedUserContext,
@@ -1433,6 +1557,60 @@ export class ApplicationsService {
         'Program A mentorship is supported only for Program A applications',
       );
     }
+  }
+
+  private ensureProgramATrackingWorkflow(
+    application: ApplicationWorkflowView,
+  ): void {
+    this.ensureProgramAApplicationLifecycle(application);
+
+    const trackingStatuses: ApplicationStatus[] = [
+      ApplicationStatus.APPROVED,
+      ApplicationStatus.ONBOARDING,
+      ApplicationStatus.ACTIVE_PROJECT,
+      ApplicationStatus.PAUSED,
+      ApplicationStatus.COMPLETED,
+    ];
+
+    if (!trackingStatuses.includes(application.status)) {
+      throw new BadRequestException(
+        `Program A tracking is allowed only for approved/post-approval applications. Current status: ${application.status}`,
+      );
+    }
+  }
+
+  private ensureProgramATrackingReadAccess(
+    application: ApplicationWorkflowView,
+    user: AuthenticatedUserContext,
+  ): void {
+    if (this.isReviewerSideUser(user)) {
+      return;
+    }
+
+    if (user.role === UserRole.MENTOR && application.mentorUserId === user.id) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'Only reviewer-side users or the assigned mentor can view Program A tracking',
+    );
+  }
+
+  private ensureProgramATrackingAccess(
+    application: ApplicationWorkflowView,
+    user: AuthenticatedUserContext,
+  ): void {
+    if (isAdminRole(user.role)) {
+      return;
+    }
+
+    if (user.role === UserRole.MENTOR && application.mentorUserId === user.id) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'Only administrators or the assigned mentor can manage Program A tracking',
+    );
   }
 
   private ensureProgramAApplicationLifecycle(
@@ -2063,6 +2241,77 @@ export class ApplicationsService {
       content: note.content,
       createdAt: note.createdAt,
       author: this.toMentorshipNoteAuthorDto(note.author),
+    };
+  }
+
+  private toProgramAMilestoneDto(
+    milestone: ProgramAMilestoneWithApplication,
+  ): ProgramAMilestoneDto {
+    return {
+      id: milestone.id,
+      applicationId: milestone.applicationId,
+      title: milestone.title,
+      description: milestone.description,
+      dueAt: milestone.dueAt,
+      status: milestone.status,
+      progressNote: milestone.progressNote,
+      createdAt: milestone.createdAt,
+      updatedAt: milestone.updatedAt,
+    };
+  }
+
+  private toInternalProgramAApplicationDto(application: {
+    id: string;
+    status: ApplicationStatus;
+    submittedAt: Date | null;
+    decidedAt: Date | null;
+    mentorUserId: string | null;
+    mentorAssignedAt: Date | null;
+    mentorAssignedById: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    team: {
+      id: string;
+      name: string;
+      leaderId: string;
+    };
+    call: {
+      id: string;
+      title: string;
+      type: ProgramType;
+      status: CallStatus;
+      opensAt: Date | null;
+      closesAt: Date | null;
+    };
+    eligibilitySignals: Array<{
+      id: string;
+      code: string;
+      passed: boolean;
+      reason: string | null;
+    }>;
+  }): InternalProgramAApplicationDto {
+    return {
+      id: application.id,
+      status: application.status,
+      submittedAt: application.submittedAt,
+      decidedAt: application.decidedAt,
+      team: application.team,
+      call: application.call,
+      mentorAssignment: {
+        mentorUserId: application.mentorUserId,
+        mentorAssignedAt: application.mentorAssignedAt,
+        mentorAssignedById: application.mentorAssignedById,
+      },
+      eligibilitySignalSummary: {
+        total: application.eligibilitySignals.length,
+        passed: application.eligibilitySignals.filter((signal) => signal.passed)
+          .length,
+        failed: application.eligibilitySignals.filter(
+          (signal) => !signal.passed,
+        ).length,
+      },
+      createdAt: application.createdAt,
+      updatedAt: application.updatedAt,
     };
   }
 

--- a/src/applications/dto/create-program-a-milestone.dto.ts
+++ b/src/applications/dto/create-program-a-milestone.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { ProgramAMilestoneStatus } from '../../../generated/prisma/enums';
+
+export class CreateProgramAMilestoneDto {
+  @ApiProperty({
+    example: 'Build MVP prototype',
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(160)
+  title!: string;
+
+  @ApiPropertyOptional({
+    example: 'Prepare a working MVP version for internal demo.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-06-30T23:59:59.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  dueAt?: string;
+
+  @ApiPropertyOptional({
+    enum: ProgramAMilestoneStatus,
+    example: ProgramAMilestoneStatus.PLANNED,
+  })
+  @IsOptional()
+  @IsEnum(ProgramAMilestoneStatus)
+  status?: ProgramAMilestoneStatus;
+
+  @ApiPropertyOptional({
+    example: 'Initial planning completed.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  progressNote?: string;
+}

--- a/src/applications/dto/internal-program-a-application.dto.ts
+++ b/src/applications/dto/internal-program-a-application.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ApplicationStatus,
+  CallStatus,
+  ProgramType,
+} from '../../../generated/prisma/enums';
+
+class InternalProgramATeamDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  leaderId!: string;
+}
+
+class InternalProgramACallDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiProperty({
+    enum: ProgramType,
+  })
+  type!: ProgramType;
+
+  @ApiProperty({
+    enum: CallStatus,
+  })
+  status!: CallStatus;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  opensAt!: Date | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  closesAt!: Date | null;
+}
+
+class InternalProgramAMentorAssignmentDto {
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  mentorUserId!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  mentorAssignedAt!: Date | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  mentorAssignedById!: string | null;
+}
+
+class InternalProgramAEligibilitySignalSummaryDto {
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  passed!: number;
+
+  @ApiProperty()
+  failed!: number;
+}
+
+export class InternalProgramAApplicationDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({
+    enum: ApplicationStatus,
+  })
+  status!: ApplicationStatus;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  submittedAt!: Date | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  decidedAt!: Date | null;
+
+  @ApiProperty()
+  team!: InternalProgramATeamDto;
+
+  @ApiProperty()
+  call!: InternalProgramACallDto;
+
+  @ApiProperty()
+  mentorAssignment!: InternalProgramAMentorAssignmentDto;
+
+  @ApiProperty()
+  eligibilitySignalSummary!: InternalProgramAEligibilitySignalSummaryDto;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}

--- a/src/applications/dto/program-a-milestone.dto.ts
+++ b/src/applications/dto/program-a-milestone.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ProgramAMilestoneStatus } from '../../../generated/prisma/enums';
+
+export class ProgramAMilestoneDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  applicationId!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  description!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  dueAt!: Date | null;
+
+  @ApiProperty({
+    enum: ProgramAMilestoneStatus,
+  })
+  status!: ProgramAMilestoneStatus;
+
+  @ApiPropertyOptional({
+    nullable: true,
+  })
+  progressNote!: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}

--- a/src/applications/dto/update-program-a-milestone.dto.ts
+++ b/src/applications/dto/update-program-a-milestone.dto.ts
@@ -1,0 +1,52 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { ProgramAMilestoneStatus } from '../../../generated/prisma/enums';
+
+export class UpdateProgramAMilestoneDto {
+  @ApiPropertyOptional({
+    example: 'Build MVP prototype',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(160)
+  title?: string;
+
+  @ApiPropertyOptional({
+    example: 'Prepare a working MVP version for internal demo.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-06-30T23:59:59.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  dueAt?: string;
+
+  @ApiPropertyOptional({
+    enum: ProgramAMilestoneStatus,
+    example: ProgramAMilestoneStatus.IN_PROGRESS,
+  })
+  @IsOptional()
+  @IsEnum(ProgramAMilestoneStatus)
+  status?: ProgramAMilestoneStatus;
+
+  @ApiPropertyOptional({
+    example: 'Prototype UI is ready, backend integration is in progress.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  progressNote?: string;
+}

--- a/src/applications/program-a-milestones.repository.ts
+++ b/src/applications/program-a-milestones.repository.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@nestjs/common';
+import type { Prisma, ProgramAMilestone } from '../../generated/prisma/client';
+import { BaseRepository, PrismaDbClient } from '../infrastructure/database';
+import { PrismaService } from '../infrastructure/database/prisma.service';
+
+export type ProgramAMilestoneWithApplication =
+  Prisma.ProgramAMilestoneGetPayload<{
+    select: ReturnType<ProgramAMilestonesRepository['milestoneSelect']>;
+  }>;
+
+@Injectable()
+export class ProgramAMilestonesRepository extends BaseRepository<
+  ProgramAMilestone,
+  Prisma.ProgramAMilestoneUncheckedCreateInput,
+  Prisma.ProgramAMilestoneUncheckedUpdateInput,
+  Prisma.ProgramAMilestoneWhereInput,
+  Prisma.ProgramAMilestoneWhereUniqueInput,
+  Prisma.ProgramAMilestoneOrderByWithRelationInput
+> {
+  constructor(prisma: PrismaService) {
+    super(prisma);
+  }
+
+  protected getDelegate(db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).programAMilestone;
+  }
+
+  createMilestone(
+    data: Prisma.ProgramAMilestoneUncheckedCreateInput,
+    db?: PrismaDbClient,
+  ): Promise<ProgramAMilestoneWithApplication> {
+    return (db ?? this.prisma.client).programAMilestone.create({
+      data,
+      select: this.milestoneSelect(),
+    });
+  }
+
+  listByApplication(
+    applicationId: string,
+    db?: PrismaDbClient,
+  ): Promise<ProgramAMilestoneWithApplication[]> {
+    return (db ?? this.prisma.client).programAMilestone.findMany({
+      where: {
+        applicationId,
+      },
+      orderBy: [
+        {
+          dueAt: 'asc',
+        },
+        {
+          createdAt: 'asc',
+        },
+      ],
+      select: this.milestoneSelect(),
+    });
+  }
+
+  findByIdForApplication(
+    applicationId: string,
+    milestoneId: string,
+    db?: PrismaDbClient,
+  ): Promise<ProgramAMilestoneWithApplication | null> {
+    return (db ?? this.prisma.client).programAMilestone.findFirst({
+      where: {
+        id: milestoneId,
+        applicationId,
+      },
+      select: this.milestoneSelect(),
+    });
+  }
+
+  updateMilestone(
+    milestoneId: string,
+    data: Prisma.ProgramAMilestoneUncheckedUpdateInput,
+    db?: PrismaDbClient,
+  ): Promise<ProgramAMilestoneWithApplication> {
+    return (db ?? this.prisma.client).programAMilestone.update({
+      where: {
+        id: milestoneId,
+      },
+      data,
+      select: this.milestoneSelect(),
+    });
+  }
+
+  private milestoneSelect() {
+    return {
+      id: true,
+      applicationId: true,
+      title: true,
+      description: true,
+      dueAt: true,
+      status: true,
+      progressNote: true,
+      createdAt: true,
+      updatedAt: true,
+    } as const;
+  }
+}


### PR DESCRIPTION
## Summary

Implemented Program A internal review list and basic post-approval project tracking.

This PR adds internal reviewer/admin support for viewing Program A applications and managing lightweight Program A milestones after approval.

Closes #145

## Changes

### Database

- Added `ProgramAMilestone` model
- Added `ProgramAMilestoneStatus` enum
- Added relation between `Application` and Program A milestones
- Added Prisma migration for Program A project tracking

### Internal Program A Review

Added endpoint:

```http
GET /api/v1/admin/applications/program-a
```

Returns Program A applications for internal dashboard with:

- Application status
- Submission and decision dates
- Team information
- Call information
- Mentor assignment
- Eligibility signal summary

### Program A Project Tracking

Added endpoints:

```http
GET /api/v1/admin/applications/:id/program-a-milestones
POST /api/v1/admin/applications/:id/program-a-milestones
PATCH /api/v1/admin/applications/:id/program-a-milestones/:milestoneId
```

Milestones support:

- Title
- Description
- Due date
- Status
- Progress note

### Access Rules

- Reviewer-side users can view internal Program A applications.
- Admins and assigned mentors can manage Program A milestones.
- Students cannot access internal tracking.
- Milestones are allowed only for approved/post-approval Program A applications.

## Tests

Added tests for:

- Internal Program A application list
- Forbidden access for students
- Milestone creation by admin
- Milestone creation by assigned mentor
- Forbidden milestone creation by student
- Rejecting milestone creation before approval
- Listing milestones
- Updating milestones
- Missing milestone handling

## Validation

Successfully checked:

```bash
npm run typescript
npm test -- applications.service
npm test
```

Results:

- TypeScript passed
- ApplicationsService tests passed
- Full test suite passed: 55 test suites, 495 tests