### PR TITLE
feat(program-b): gate backlog and applications on active call window

### DIFF
--- a/docs/DEV_FIXTURES.md
+++ b/docs/DEV_FIXTURES.md
@@ -1,0 +1,173 @@
+# Dev Fixtures Reference
+
+Run with: `npm run seed:dev`  
+All accounts use password: **`Dev1234!`**
+
+---
+
+## System Users
+
+| Email | Role | Name |
+|---|---|---|
+| `admin@nti.sk` | SUPER_ADMIN | NTI Superadmin *(from seed 001)* |
+| `admin1@dev.local` | ADMIN | Anna Kováčová |
+| `admin2@dev.local` | ADMIN | Peter Novák |
+| `mentor1@dev.local` | MENTOR | Ján Horváth |
+| `mentor2@dev.local` | MENTOR | Eva Šimková |
+| `mentor3@dev.local` | MENTOR | Michal Blaho |
+| `evaluator1@dev.local` | EVALUATOR | Lucia Marková |
+| `evaluator2@dev.local` | EVALUATOR | Tomáš Rusnák |
+| `editor1@dev.local` | CONTENT_EDITOR | Zuzana Benčíková |
+
+---
+
+## Organizations & Company Users
+
+| Organization | IČO | Sector | Status |
+|---|---|---|---|
+| TechNova s.r.o. | 11111111 | Technology | ACTIVE |
+| GreenSolutions a.s. | 22222222 | Environment | ACTIVE |
+| DataDriven s.r.o. | 33333333 | Analytics | ACTIVE |
+| StartupXYZ s.r.o. | 44444444 | Fintech | ACTIVE |
+
+| Email | Role | Organization |
+|---|---|---|
+| `owner@technova.dev.local` | COMPANY_OWNER | TechNova s.r.o. |
+| `employee@technova.dev.local` | COMPANY_EMPLOYEE | TechNova s.r.o. |
+| `owner@green.dev.local` | COMPANY_OWNER | GreenSolutions a.s. |
+| `owner@data.dev.local` | COMPANY_OWNER | DataDriven s.r.o. |
+| `owner@startup.dev.local` | COMPANY_OWNER | StartupXYZ s.r.o. |
+
+---
+
+## Students
+
+| Email | Name | University | Faculty | Specialization | Degree | Year | Primary Skills |
+|---|---|---|---|---|---|---|---|
+| `student01@dev.local` | Adam Baláž | STU | FEI | Softvérové inžinierstvo | MASTER | 2 | TypeScript (ADV), Node.js (ADV), React (INT) |
+| `student02@dev.local` | Barbora Čierná | STU | FEI | Softvérové inžinierstvo | BACHELOR | 3 | Java (INT), Spring Boot (INT) |
+| `student03@dev.local` | Cyril Dobiáš | STU | FIIT | Umelá inteligencia | MASTER | 1 | Python (ADV), TensorFlow (ADV), PyTorch (INT) |
+| `student04@dev.local` | Dana Ertlová | UK | FMFI | Informatika | MASTER | 2 | Python (ADV), scikit-learn (INT), TypeScript (BEG) |
+| `student05@dev.local` | Eduard Farkaš | UK | FMFI | Informatika | BACHELOR | 3 | React (ADV), React Native (INT), CSS (ADV) |
+| `student06@dev.local` | Fiona Gáborová | STU | FIIT | Umelá inteligencia | MASTER | 1 | Python (ADV), Keras (INT) |
+| `student07@dev.local` | Gregor Hlúpik | STU | FIIT | Umelá inteligencia | BACHELOR | 2 | Python (ADV), Docker (INT), Kubernetes (BEG) |
+| `student08@dev.local` | Helena Ivánová | STU | FEI | Softvérové inžinierstvo | BACHELOR | 3 | Vue.js (INT), TypeScript (INT) |
+| `student09@dev.local` | Ivan Jakubík | UK | FMFI | Informatika | MASTER | 2 | Go (ADV), Docker (ADV), PostgreSQL (ADV) |
+| `student10@dev.local` | Jana Kováčová | EKON | NHF | Financie | BACHELOR | 2 | Figma (INT), Jira (INT) |
+| `student11@dev.local` | Karol Lukáč | STU | FEI | Softvérové inžinierstvo | MASTER | 1 | TypeScript (ADV), NestJS (INT), React (INT) |
+| `student12@dev.local` | Lenka Malíková | STU | FIIT | Umelá inteligencia | BACHELOR | 3 | Python (INT), TensorFlow (BEG) |
+| `student13@dev.local` | Martin Nemec | UK | FMFI | Informatika | BACHELOR | 1 | React (INT), React Native (BEG) |
+| `student14@dev.local` | Nina Oravec | EKON | NHF | Financie | MASTER | 2 | Notion (ADV), Figma (ADV), Excel (ADV) |
+| `student15@dev.local` | Ondrej Polák | STU | FEI | Softvérové inžinierstvo | BACHELOR | 2 | TypeScript (INT), Node.js (BEG) |
+
+---
+
+## Teams
+
+| Team | Leader | Members | Locked |
+|---|---|---|---|
+| Team Alpha | student01 | student01, student02, student03 | No |
+| Team Beta | student04 | student04, student05 | No |
+| Team Gamma | student06 | student06, student07, student08 | No |
+| Team Delta | student09 | student09, student10 | No |
+| Team Epsilon | student11 | student11, student12 | No |
+
+---
+
+## Backlog Items (Program B)
+
+| # | Title | Organization | Status | Budget |
+|---|---|---|---|---|
+| 1 | Automatizovaný onboarding systém pre zamestnancov | TechNova | **IN_REALIZATION** | €9 500 |
+| 2 | AI asistent pre zákaznícku podporu | TechNova | **ASSIGNED** | €8 000 |
+| 3 | Dashboard pre monitorovanie spotreby energie | GreenSolutions | **IN_PAIRING** | €6 000 |
+| 4 | Mobilná aplikácia pre komunitné záhrady | GreenSolutions | **IN_PAIRING** | €5 500 |
+| 5 | Automatická generácia reportov z ERP dát | DataDriven | **PUBLISHED** | €7 000 |
+| 6 | Prediktívna analytika pre inventory management | DataDriven | **PUBLISHED** | €11 000 |
+| 7 | P2P platforma pre mikropôžičky | StartupXYZ | **PUBLISHED** | €15 000 |
+| 8 | Interný knowledge base s AI vyhľadávaním | TechNova | **DRAFT** | €8 500 |
+| 9 | Web scraper pre monitoring cien energií | GreenSolutions | **CLOSED** | €3 000 |
+
+---
+
+## Program B — Team Applications
+
+| Team | Backlog Item | Status | Notes |
+|---|---|---|---|
+| Team Alpha | #1 Onboarding systém | **PROJECT_CREATED** | Project was created, now IN_REALIZATION |
+| Team Beta | #2 AI asistent | **ACCEPTED** | Project created, awaiting mentor assignment |
+| Team Gamma | #3 Energy dashboard | **SHORTLISTED** | Competing with Team Epsilon |
+| Team Epsilon | #3 Energy dashboard | **SUBMITTED** | Competing with Team Gamma |
+| Team Delta | #4 Komunitné záhrady | **SUBMITTED** | Under review |
+
+---
+
+## Program B — Active Projects
+
+### Project 1 — Team Alpha × TechNova (Onboarding systém)
+- **Status:** ACTIVE
+- **Mentor:** mentor1@dev.local
+- **Product Owner:** owner@technova.dev.local
+- **Accepted by company:** 18 days ago · **Accepted by NTI:** 17 days ago
+
+| Milestone | Status |
+|---|---|
+| Analýza požiadaviek a ER diagram | DONE |
+| Backend API (NestJS + Prisma) | IN_PROGRESS |
+| Frontend integrácia | PLANNED |
+| AD integrácia | PLANNED |
+| Testovanie a odovzdanie | PLANNED |
+
+- 3 mentoring notes from mentor1
+- 1 PO review: APPROVED
+
+### Project 2 — Team Beta × TechNova (AI asistent)
+- **Status:** ACTIVE
+- **Mentor:** *(not yet assigned)*
+- **Product Owner:** owner@technova.dev.local
+- **Accepted by company:** 8 days ago
+
+---
+
+## Program A — Applications
+
+| Team | Status | Mentor | Notes |
+|---|---|---|---|
+| Team Alpha | **ACTIVE_PROJECT** | mentor2@dev.local | Full history: DRAFT → SUBMITTED → FORMALLY_VERIFIED → EVALUATING → APPROVED → ONBOARDING → ACTIVE_PROJECT |
+| Team Beta | **EVALUATING** | — | 2 evaluations: evaluator1 (APPROVE), evaluator2 (NEEDS_INFO) |
+| Team Gamma | **NEEDS_INFO** | — | 1 open NeedsInfo item (due in 7 days): financial plan details requested |
+| Team Delta | **SUBMITTED** | — | Submitted 3 days ago |
+| Team Epsilon | **DRAFT** | — | Not yet submitted |
+
+### Team Alpha — Program A Detail
+- **Milestones:**
+
+| Milestone | Status |
+|---|---|
+| Kick-off a definícia MVP | DONE |
+| Prototyp a používateľské testovanie | IN_PROGRESS |
+| Beta verzia | PLANNED |
+| Finálne odovzdanie | PLANNED |
+
+- 2 mentorship notes from mentor2
+
+### Team Beta — Evaluation Scores
+
+| Criterion | evaluator1 | evaluator2 |
+|---|---|---|
+| innovation | 4 | 5 |
+| technical_feasibility | 4 | 3 |
+| team_quality | 5 | 4 |
+| market_potential | 4 | 3 |
+| **Recommendation** | APPROVE | NEEDS_INFO |
+
+---
+
+## University Structure
+
+| University | Short | Faculty | Short | Specialization | Code |
+|---|---|---|---|---|---|
+| Slovenská technická univerzita | STU | Fakulta elektrotechniky a informatiky | FEI | Softvérové inžinierstvo | SI |
+| Slovenská technická univerzita | STU | Fakulta informatiky a inf. technológií | FIIT | Umelá inteligencia | AI |
+| Univerzita Komenského | UK | Fakulta matematiky, fyziky a informatiky | FMFI | Informatika | INF |
+| Ekonomická univerzita | EKON | Národohospodárska fakulta | NHF | Financie | FIN |

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:studio": "prisma studio",
     "prisma:reset": "prisma migrate reset",
-    "prisma:seed": "prisma db seed"
+    "prisma:seed": "prisma db seed",
+    "seed:dev": "node --experimental-strip-types --experimental-specifier-resolution=node prisma/seed/dev.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.926.0",

--- a/prisma/seed/dev.ts
+++ b/prisma/seed/dev.ts
@@ -1,0 +1,71 @@
+import 'dotenv/config';
+import argon2 from 'argon2';
+import { Client } from 'pg';
+import type { SeedContext, SeedTask } from './types';
+
+async function loadSeeds(): Promise<SeedTask[]> {
+  const { superadminSeed } =
+    (await import('./seeds/001-superadmin.seed.ts')) as {
+      superadminSeed: SeedTask;
+    };
+
+  const { callsSeed } = (await import('./seeds/002-calls.seed.ts')) as {
+    callsSeed: SeedTask;
+  };
+
+  const { programBBacklogSeed } =
+    (await import('./seeds/003-program-b-backlog.seed.ts')) as {
+      programBBacklogSeed: SeedTask;
+    };
+
+  const { devFixturesSeed } =
+    (await import('./seeds/004-dev-fixtures.seed.ts')) as {
+      devFixturesSeed: SeedTask;
+    };
+
+  return [superadminSeed, callsSeed, programBBacklogSeed, devFixturesSeed];
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL must be set');
+  }
+
+  const argon2TimeCost = Number(process.env.ARGON2_TIME_COST ?? 3);
+
+  if (!Number.isInteger(argon2TimeCost) || argon2TimeCost <= 0) {
+    throw new Error('ARGON2_TIME_COST must be a positive integer');
+  }
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  const context: SeedContext = {
+    client,
+    hashPassword: (plainPassword: string) =>
+      argon2.hash(plainPassword, {
+        type: argon2.argon2id,
+        timeCost: argon2TimeCost,
+      }),
+    now: () => new Date(),
+  };
+
+  try {
+    const seeds = await loadSeeds();
+
+    for (const seed of seeds) {
+      console.info(`[seed] running ${seed.name}`);
+      await seed.run(context);
+      console.info(`[seed] done ${seed.name}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('[seed] failed', error);
+  process.exit(1);
+});

--- a/prisma/seed/seeds/002-calls.seed.ts
+++ b/prisma/seed/seeds/002-calls.seed.ts
@@ -42,6 +42,16 @@ export const callsSeed: SeedTask = {
       );
 
       if (existingCall.rowCount && existingCall.rowCount > 0) {
+        await context.client.query(
+          `UPDATE "Call" SET title = $1, status = $2, "opensAt" = $3, "closesAt" = $4, "updatedAt" = NOW() WHERE id = $5`,
+          [
+            call.title,
+            call.status,
+            call.opensAt,
+            call.closesAt,
+            existingCall.rows[0].id,
+          ],
+        );
         continue;
       }
 

--- a/prisma/seed/seeds/003-program-b-backlog.seed.ts
+++ b/prisma/seed/seeds/003-program-b-backlog.seed.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import type { SeedTask } from '../types';
+
+const COMPANY_EMAIL = 'company-owner@seed.local';
+const COMPANY_PASSWORD = 'Seed1234!';
+
+export const programBBacklogSeed: SeedTask = {
+  name: '003-program-b-backlog',
+  async run(context) {
+    const now = context.now();
+
+    // Skip if backlog items already seeded
+    const existing = await context.client.query(
+      `SELECT id FROM "BacklogItem" WHERE status = 'PUBLISHED' LIMIT 1`,
+    );
+    if (existing.rowCount && existing.rowCount > 0) {
+      return;
+    }
+
+    // Create org
+    const orgId = randomUUID();
+    await context.client.query(
+      `INSERT INTO "Organization" (id, name, ico, sector, description, website, status, "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       ON CONFLICT (ico) DO NOTHING`,
+      [
+        orgId,
+        'Seed Corp s.r.o.',
+        '12345678',
+        'Technology',
+        'A seed company for local development testing.',
+        'https://seedcorp.example',
+        'ACTIVE',
+        now,
+        now,
+      ],
+    );
+
+    const orgRow = await context.client.query<{ id: string }>(
+      `SELECT id FROM "Organization" WHERE ico = '12345678' LIMIT 1`,
+    );
+    const resolvedOrgId = orgRow.rows[0].id;
+
+    // Create company owner user
+    const userExists = await context.client.query(
+      `SELECT id FROM "User" WHERE email = $1 LIMIT 1`,
+      [COMPANY_EMAIL],
+    );
+
+    let companyOwnerId: string;
+
+    if (userExists.rowCount && userExists.rowCount > 0) {
+      companyOwnerId = (userExists.rows[0] as { id: string }).id;
+    } else {
+      companyOwnerId = randomUUID();
+      const passwordHash = await context.hashPassword(COMPANY_PASSWORD);
+
+      await context.client.query(
+        `INSERT INTO "User" (id, "firstName", "lastName", email, "passwordHash", role, status, "isConfirmed", "isAdminConfirmed", "mustChangePassword", "organizationId", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+        [
+          companyOwnerId,
+          'Seed',
+          'Owner',
+          COMPANY_EMAIL,
+          passwordHash,
+          'COMPANY_OWNER',
+          'ACTIVE',
+          true,
+          true,
+          false,
+          resolvedOrgId,
+          now,
+          now,
+        ],
+      );
+    }
+
+    // Create 3 published backlog items
+    const items = [
+      {
+        title: 'AI-powered customer support chatbot',
+        description:
+          'Build an intelligent chatbot that handles tier-1 customer support queries using LLMs. The system should integrate with our existing CRM and escalate complex issues to human agents automatically.',
+        budget: 8000,
+        expectedOutcomes:
+          'Working chatbot prototype, integration with CRM API, handoff workflow documentation, test coverage ≥ 70%.',
+      },
+      {
+        title: 'Internal HR self-service portal',
+        description:
+          'Develop a web portal where employees can submit leave requests, view payslips, and update personal data without contacting HR directly. Must comply with GDPR.',
+        budget: 6500,
+        expectedOutcomes:
+          'GDPR-compliant portal, leave request workflow, payslip PDF export, admin dashboard for HR managers.',
+      },
+      {
+        title: 'Real-time logistics tracking dashboard',
+        description:
+          'Create a dashboard that shows live delivery status for all active shipments. Data comes from third-party carrier APIs. Stakeholders need ETA predictions and exception alerts.',
+        budget: 5000,
+        expectedOutcomes:
+          'Live map view with shipment markers, ETA calculation, email/SMS alert system for delays, mobile-responsive UI.',
+      },
+    ];
+
+    for (const item of items) {
+      await context.client.query(
+        `INSERT INTO "BacklogItem" (id, "organizationId", title, description, budget, "expectedOutcomes", status, "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4, $5, $6, 'PUBLISHED', $7, $8)`,
+        [
+          randomUUID(),
+          resolvedOrgId,
+          item.title,
+          item.description,
+          item.budget,
+          item.expectedOutcomes,
+          now,
+          now,
+        ],
+      );
+    }
+
+    console.info(
+      `[seed] company owner login: ${COMPANY_EMAIL} / ${COMPANY_PASSWORD}`,
+    );
+  },
+};

--- a/prisma/seed/seeds/004-dev-fixtures.seed.ts
+++ b/prisma/seed/seeds/004-dev-fixtures.seed.ts
@@ -1,0 +1,1504 @@
+import { randomUUID } from 'node:crypto';
+import type { SeedTask } from '../types';
+
+const DEV_PASSWORD = 'Dev1234!';
+
+// ---------------------------------------------------------------------------
+// Deterministic IDs so re-runs stay idempotent
+// ---------------------------------------------------------------------------
+const IDS = {
+  // Universities
+  univSTU: randomUUID(),
+  univUK: randomUUID(),
+  univEKON: randomUUID(),
+
+  // Faculties
+  facFEI: randomUUID(),
+  facFIIT: randomUUID(),
+  facMFF: randomUUID(),
+  facNHF: randomUUID(),
+
+  // Specializations
+  specSoftEng: randomUUID(),
+  specAI: randomUUID(),
+  specCS: randomUUID(),
+  specFinance: randomUUID(),
+
+  // Organizations
+  orgTechNova: randomUUID(),
+  orgGreenSolutions: randomUUID(),
+  orgDataDriven: randomUUID(),
+  orgStartupXYZ: randomUUID(),
+
+  // System users
+  admin1: randomUUID(),
+  admin2: randomUUID(),
+  mentor1: randomUUID(),
+  mentor2: randomUUID(),
+  mentor3: randomUUID(),
+  evaluator1: randomUUID(),
+  evaluator2: randomUUID(),
+  editor1: randomUUID(),
+
+  // Company owners/employees
+  ownerTechNova: randomUUID(),
+  empTechNova: randomUUID(),
+  ownerGreen: randomUUID(),
+  ownerData: randomUUID(),
+  ownerStartup: randomUUID(),
+
+  // Students
+  student01: randomUUID(),
+  student02: randomUUID(),
+  student03: randomUUID(),
+  student04: randomUUID(),
+  student05: randomUUID(),
+  student06: randomUUID(),
+  student07: randomUUID(),
+  student08: randomUUID(),
+  student09: randomUUID(),
+  student10: randomUUID(),
+  student11: randomUUID(),
+  student12: randomUUID(),
+  student13: randomUUID(),
+  student14: randomUUID(),
+  student15: randomUUID(),
+
+  // Student profiles
+  sp01: randomUUID(),
+  sp02: randomUUID(),
+  sp03: randomUUID(),
+  sp04: randomUUID(),
+  sp05: randomUUID(),
+  sp06: randomUUID(),
+  sp07: randomUUID(),
+  sp08: randomUUID(),
+  sp09: randomUUID(),
+  sp10: randomUUID(),
+  sp11: randomUUID(),
+  sp12: randomUUID(),
+  sp13: randomUUID(),
+  sp14: randomUUID(),
+  sp15: randomUUID(),
+
+  // Teams
+  teamAlpha: randomUUID(),
+  teamBeta: randomUUID(),
+  teamGamma: randomUUID(),
+  teamDelta: randomUUID(),
+  teamEpsilon: randomUUID(),
+
+  // Backlog items
+  backlog01: randomUUID(),
+  backlog02: randomUUID(),
+  backlog03: randomUUID(),
+  backlog04: randomUUID(),
+  backlog05: randomUUID(),
+  backlog06: randomUUID(),
+  backlog07: randomUUID(),
+  backlog08: randomUUID(),
+  backlog09: randomUUID(),
+
+  // Program B team applications
+  pbApp01: randomUUID(),
+  pbApp02: randomUUID(),
+  pbApp03: randomUUID(),
+  pbApp04: randomUUID(),
+  pbApp05: randomUUID(),
+
+  // Program B projects
+  pbProject01: randomUUID(),
+  pbProject02: randomUUID(),
+
+  // Program A applications
+  paApp01: randomUUID(),
+  paApp02: randomUUID(),
+  paApp03: randomUUID(),
+  paApp04: randomUUID(),
+  paApp05: randomUUID(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function upsertUser(
+  client: {
+    query: (
+      sql: string,
+      params?: unknown[],
+    ) => Promise<{ rowCount: number | null }>;
+  },
+  id: string,
+  fields: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    passwordHash: string;
+    role: string;
+    status?: string;
+    isConfirmed?: boolean;
+    isAdminConfirmed?: boolean;
+    mustChangePassword?: boolean;
+    organizationId?: string | null;
+    now: Date;
+  },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO "User" (
+      id, "firstName", "lastName", email, "passwordHash", role, status,
+      "isConfirmed", "isAdminConfirmed", "mustChangePassword", "organizationId",
+      "createdAt", "updatedAt"
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+    ON CONFLICT (email) DO NOTHING`,
+    [
+      id,
+      fields.firstName,
+      fields.lastName,
+      fields.email,
+      fields.passwordHash,
+      fields.role,
+      fields.status ?? 'ACTIVE',
+      fields.isConfirmed ?? true,
+      fields.isAdminConfirmed ?? true,
+      fields.mustChangePassword ?? false,
+      fields.organizationId ?? null,
+      fields.now,
+      fields.now,
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main seed
+// ---------------------------------------------------------------------------
+export const devFixturesSeed: SeedTask = {
+  name: '004-dev-fixtures',
+
+  async run(context) {
+    const { client, hashPassword, now: getNow } = context;
+    const now = getNow();
+
+    // Skip if already seeded
+    const marker = await client.query(
+      `SELECT id FROM "User" WHERE email = 'admin1@dev.local' LIMIT 1`,
+    );
+    if (marker.rowCount && marker.rowCount > 0) {
+      return;
+    }
+
+    const pw = await hashPassword(DEV_PASSWORD);
+
+    // -----------------------------------------------------------------------
+    // Universities / Faculties / Specializations
+    // -----------------------------------------------------------------------
+    await client.query(
+      `INSERT INTO "University" (id, name, "shortName", city, country, "isActive", "createdAt", "updatedAt")
+       VALUES
+         ($1, 'Slovenská technická univerzita v Bratislave', 'STU', 'Bratislava', 'sk', true, $4, $4),
+         ($2, 'Univerzita Komenského v Bratislave', 'UK', 'Bratislava', 'sk', true, $4, $4),
+         ($3, 'Ekonomická univerzita v Bratislave', 'EKON', 'Bratislava', 'sk', true, $4, $4)
+       ON CONFLICT (name) DO NOTHING`,
+      [IDS.univSTU, IDS.univUK, IDS.univEKON, now],
+    );
+
+    const univSTUId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "University" WHERE "shortName" = 'STU' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const univUKId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "University" WHERE "shortName" = 'UK' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const univEKONId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "University" WHERE "shortName" = 'EKON' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    await client.query(
+      `INSERT INTO "Faculty" (id, "universityId", name, "shortName", "isActive", "createdAt", "updatedAt")
+       VALUES
+         ($1, $5, 'Fakulta elektrotechniky a informatiky', 'FEI', true, $9, $9),
+         ($2, $5, 'Fakulta informatiky a informačných technológií', 'FIIT', true, $9, $9),
+         ($3, $6, 'Fakulta matematiky, fyziky a informatiky', 'FMFI', true, $9, $9),
+         ($4, $7, 'Národohospodárska fakulta', 'NHF', true, $9, $9)
+       ON CONFLICT ("universityId", name) DO NOTHING`,
+      [
+        IDS.facFEI,
+        IDS.facFIIT,
+        IDS.facMFF,
+        IDS.facNHF,
+        univSTUId,
+        univUKId,
+        univEKONId,
+        null,
+        now,
+      ],
+    );
+
+    const facFEIId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Faculty" WHERE "shortName" = 'FEI' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const facFIITId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Faculty" WHERE "shortName" = 'FIIT' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const facMFFId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Faculty" WHERE "shortName" = 'FMFI' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const facNHFId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Faculty" WHERE "shortName" = 'NHF' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    await client.query(
+      `INSERT INTO "Specialization" (id, "facultyId", name, code, "degreeLabel", "isActive", "createdAt", "updatedAt")
+       VALUES
+         ($1, $5, 'Softvérové inžinierstvo', 'SI', 'Bc./Ing.', true, $9, $9),
+         ($2, $6, 'Umelá inteligencia', 'AI', 'Bc./Ing.', true, $9, $9),
+         ($3, $7, 'Informatika', 'INF', 'Bc./Mgr.', true, $9, $9),
+         ($4, $8, 'Financie', 'FIN', 'Bc./Ing.', true, $9, $9)
+       ON CONFLICT ("facultyId", name) DO NOTHING`,
+      [
+        IDS.specSoftEng,
+        IDS.specAI,
+        IDS.specCS,
+        IDS.specFinance,
+        facFEIId,
+        facFIITId,
+        facMFFId,
+        facNHFId,
+        now,
+      ],
+    );
+
+    const specSoftEngId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Specialization" WHERE code = 'SI' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const specAIId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Specialization" WHERE code = 'AI' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const specCSId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Specialization" WHERE code = 'INF' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const specFinanceId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Specialization" WHERE code = 'FIN' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    // -----------------------------------------------------------------------
+    // Organizations
+    // -----------------------------------------------------------------------
+    await client.query(
+      `INSERT INTO "Organization" (id, name, ico, sector, description, website, status, "createdAt", "updatedAt")
+       VALUES
+         ($1, 'TechNova s.r.o.',       '11111111', 'Technology',  'Inovatívna softvérová spoločnosť zameraná na AI a cloud riešenia.', 'https://technova.dev', 'ACTIVE', $5, $5),
+         ($2, 'GreenSolutions a.s.',   '22222222', 'Environment', 'Spoločnosť poskytujúca riešenia pre udržateľnosť a zelené technológie.', 'https://greensolutions.sk', 'ACTIVE', $5, $5),
+         ($3, 'DataDriven s.r.o.',     '33333333', 'Analytics',   'Dátová analytika a business intelligence pre stredné podniky.', 'https://datadriven.sk', 'ACTIVE', $5, $5),
+         ($4, 'StartupXYZ s.r.o.',     '44444444', 'Fintech',     'Fintech startup budujúci next-gen platforné riešenia.', 'https://startupxyz.io', 'ACTIVE', $5, $5)
+       ON CONFLICT (ico) DO NOTHING`,
+      [
+        IDS.orgTechNova,
+        IDS.orgGreenSolutions,
+        IDS.orgDataDriven,
+        IDS.orgStartupXYZ,
+        now,
+      ],
+    );
+
+    const orgTechNovaId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Organization" WHERE ico = '11111111' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const orgGreenId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Organization" WHERE ico = '22222222' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const orgDataId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Organization" WHERE ico = '33333333' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const orgStartupId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "Organization" WHERE ico = '44444444' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    // -----------------------------------------------------------------------
+    // System users: admins, mentors, evaluators, editor
+    // -----------------------------------------------------------------------
+    const systemUsers = [
+      {
+        id: IDS.admin1,
+        firstName: 'Anna',
+        lastName: 'Kováčová',
+        email: 'admin1@dev.local',
+        role: 'ADMIN',
+      },
+      {
+        id: IDS.admin2,
+        firstName: 'Peter',
+        lastName: 'Novák',
+        email: 'admin2@dev.local',
+        role: 'ADMIN',
+      },
+      {
+        id: IDS.mentor1,
+        firstName: 'Ján',
+        lastName: 'Horváth',
+        email: 'mentor1@dev.local',
+        role: 'MENTOR',
+      },
+      {
+        id: IDS.mentor2,
+        firstName: 'Eva',
+        lastName: 'Šimková',
+        email: 'mentor2@dev.local',
+        role: 'MENTOR',
+      },
+      {
+        id: IDS.mentor3,
+        firstName: 'Michal',
+        lastName: 'Blaho',
+        email: 'mentor3@dev.local',
+        role: 'MENTOR',
+      },
+      {
+        id: IDS.evaluator1,
+        firstName: 'Lucia',
+        lastName: 'Marková',
+        email: 'evaluator1@dev.local',
+        role: 'EVALUATOR',
+      },
+      {
+        id: IDS.evaluator2,
+        firstName: 'Tomáš',
+        lastName: 'Rusnák',
+        email: 'evaluator2@dev.local',
+        role: 'EVALUATOR',
+      },
+      {
+        id: IDS.editor1,
+        firstName: 'Zuzana',
+        lastName: 'Benčíková',
+        email: 'editor1@dev.local',
+        role: 'CONTENT_EDITOR',
+      },
+    ];
+
+    for (const u of systemUsers) {
+      await upsertUser(client, u.id, { ...u, passwordHash: pw, now });
+    }
+
+    // -----------------------------------------------------------------------
+    // Company owners & employees
+    // -----------------------------------------------------------------------
+    await upsertUser(client, IDS.ownerTechNova, {
+      firstName: 'Rastislav',
+      lastName: 'Krajči',
+      email: 'owner@technova.dev.local',
+      passwordHash: pw,
+      role: 'COMPANY_OWNER',
+      organizationId: orgTechNovaId,
+      now,
+    });
+    await upsertUser(client, IDS.empTechNova, {
+      firstName: 'Monika',
+      lastName: 'Vargová',
+      email: 'employee@technova.dev.local',
+      passwordHash: pw,
+      role: 'COMPANY_EMPLOYEE',
+      organizationId: orgTechNovaId,
+      now,
+    });
+    await upsertUser(client, IDS.ownerGreen, {
+      firstName: 'Branislav',
+      lastName: 'Zelený',
+      email: 'owner@green.dev.local',
+      passwordHash: pw,
+      role: 'COMPANY_OWNER',
+      organizationId: orgGreenId,
+      now,
+    });
+    await upsertUser(client, IDS.ownerData, {
+      firstName: 'Katarína',
+      lastName: 'Dávidová',
+      email: 'owner@data.dev.local',
+      passwordHash: pw,
+      role: 'COMPANY_OWNER',
+      organizationId: orgDataId,
+      now,
+    });
+    await upsertUser(client, IDS.ownerStartup, {
+      firstName: 'Filip',
+      lastName: 'Starý',
+      email: 'owner@startup.dev.local',
+      passwordHash: pw,
+      role: 'COMPANY_OWNER',
+      organizationId: orgStartupId,
+      now,
+    });
+
+    // -----------------------------------------------------------------------
+    // Students (15)
+    // -----------------------------------------------------------------------
+    const students = [
+      // id,   firstName,  lastName,   email,                  univId,    facId,     specId,        degree,     year
+      [
+        IDS.student01,
+        'Adam',
+        'Baláž',
+        'student01@dev.local',
+        univSTUId,
+        facFEIId,
+        specSoftEngId,
+        'MASTER',
+        2,
+      ],
+      [
+        IDS.student02,
+        'Barbora',
+        'Čierná',
+        'student02@dev.local',
+        univSTUId,
+        facFEIId,
+        specSoftEngId,
+        'BACHELOR',
+        3,
+      ],
+      [
+        IDS.student03,
+        'Cyril',
+        'Dobiáš',
+        'student03@dev.local',
+        univSTUId,
+        facFIITId,
+        specAIId,
+        'MASTER',
+        1,
+      ],
+      [
+        IDS.student04,
+        'Dana',
+        'Ertlová',
+        'student04@dev.local',
+        univUKId,
+        facMFFId,
+        specCSId,
+        'MASTER',
+        2,
+      ],
+      [
+        IDS.student05,
+        'Eduard',
+        'Farkaš',
+        'student05@dev.local',
+        univUKId,
+        facMFFId,
+        specCSId,
+        'BACHELOR',
+        3,
+      ],
+      [
+        IDS.student06,
+        'Fiona',
+        'Gáborová',
+        'student06@dev.local',
+        univSTUId,
+        facFIITId,
+        specAIId,
+        'MASTER',
+        1,
+      ],
+      [
+        IDS.student07,
+        'Gregor',
+        'Hlúpik',
+        'student07@dev.local',
+        univSTUId,
+        facFIITId,
+        specAIId,
+        'BACHELOR',
+        2,
+      ],
+      [
+        IDS.student08,
+        'Helena',
+        'Ivánová',
+        'student08@dev.local',
+        univSTUId,
+        facFEIId,
+        specSoftEngId,
+        'BACHELOR',
+        3,
+      ],
+      [
+        IDS.student09,
+        'Ivan',
+        'Jakubík',
+        'student09@dev.local',
+        univUKId,
+        facMFFId,
+        specCSId,
+        'MASTER',
+        2,
+      ],
+      [
+        IDS.student10,
+        'Jana',
+        'Kováčová',
+        'student10@dev.local',
+        univEKONId,
+        facNHFId,
+        specFinanceId,
+        'BACHELOR',
+        2,
+      ],
+      [
+        IDS.student11,
+        'Karol',
+        'Lukáč',
+        'student11@dev.local',
+        univSTUId,
+        facFEIId,
+        specSoftEngId,
+        'MASTER',
+        1,
+      ],
+      [
+        IDS.student12,
+        'Lenka',
+        'Malíková',
+        'student12@dev.local',
+        univSTUId,
+        facFIITId,
+        specAIId,
+        'BACHELOR',
+        3,
+      ],
+      [
+        IDS.student13,
+        'Martin',
+        'Nemec',
+        'student13@dev.local',
+        univUKId,
+        facMFFId,
+        specCSId,
+        'BACHELOR',
+        1,
+      ],
+      [
+        IDS.student14,
+        'Nina',
+        'Oravec',
+        'student14@dev.local',
+        univEKONId,
+        facNHFId,
+        specFinanceId,
+        'MASTER',
+        2,
+      ],
+      [
+        IDS.student15,
+        'Ondrej',
+        'Polák',
+        'student15@dev.local',
+        univSTUId,
+        facFEIId,
+        specSoftEngId,
+        'BACHELOR',
+        2,
+      ],
+    ] as const;
+
+    for (const [id, firstName, lastName, email, , , , ,] of students) {
+      await upsertUser(client, id, {
+        firstName,
+        lastName,
+        email,
+        passwordHash: pw,
+        role: 'STUDENT',
+        now,
+      });
+    }
+
+    // Student profiles
+    const spIds = [
+      IDS.sp01,
+      IDS.sp02,
+      IDS.sp03,
+      IDS.sp04,
+      IDS.sp05,
+      IDS.sp06,
+      IDS.sp07,
+      IDS.sp08,
+      IDS.sp09,
+      IDS.sp10,
+      IDS.sp11,
+      IDS.sp12,
+      IDS.sp13,
+      IDS.sp14,
+      IDS.sp15,
+    ];
+    const studentFocusAreas: string[][] = [
+      ['SOFTWARE_DEVELOPMENT', 'WEB_APPLICATIONS'],
+      ['SOFTWARE_DEVELOPMENT'],
+      ['AI_AND_DATA'],
+      ['AI_AND_DATA', 'SOFTWARE_DEVELOPMENT'],
+      ['WEB_APPLICATIONS', 'MOBILE_DEVELOPMENT'],
+      ['AI_AND_DATA'],
+      ['AI_AND_DATA', 'DEVOPS_AND_INFRASTRUCTURE'],
+      ['WEB_APPLICATIONS'],
+      ['SOFTWARE_DEVELOPMENT', 'DEVOPS_AND_INFRASTRUCTURE'],
+      ['PRODUCT_PROJECT_MANAGEMENT'],
+      ['SOFTWARE_DEVELOPMENT', 'WEB_APPLICATIONS'],
+      ['AI_AND_DATA'],
+      ['WEB_APPLICATIONS', 'MOBILE_DEVELOPMENT'],
+      ['PRODUCT_PROJECT_MANAGEMENT', 'UI_UX_DESIGN'],
+      ['SOFTWARE_DEVELOPMENT'],
+    ];
+    const studentRoles: string[][] = [
+      ['FULLSTACK', 'BACKEND'],
+      ['BACKEND'],
+      ['AI_DATA'],
+      ['AI_DATA', 'BACKEND'],
+      ['FRONTEND', 'MOBILE'],
+      ['AI_DATA'],
+      ['AI_DATA', 'DEVOPS'],
+      ['FRONTEND'],
+      ['BACKEND', 'DEVOPS'],
+      ['PRODUCT_MANAGER'],
+      ['FULLSTACK'],
+      ['AI_DATA'],
+      ['FRONTEND', 'MOBILE'],
+      ['PRODUCT_MANAGER', 'UI_UX'],
+      ['BACKEND'],
+    ];
+
+    for (let i = 0; i < students.length; i++) {
+      const [userId, , , , univId, facId, specId, degree, year] = students[i];
+      const spId = spIds[i];
+      await client.query(
+        `INSERT INTO "StudentProfile" (
+          id, "userId", "universityId", "facultyId", "specializationId",
+          "degreeLevel", "studyMode", "studyYear", "expectedGraduationYear",
+          "focusAreas", "preferredRoles", "softSkills",
+          "createdAt", "updatedAt"
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$13)
+        ON CONFLICT ("userId") DO NOTHING`,
+        [
+          spId,
+          userId,
+          univId,
+          facId,
+          specId,
+          degree,
+          'FULL_TIME',
+          year,
+          2026 + (2 - (year as number)),
+          studentFocusAreas[i],
+          studentRoles[i],
+          ['TEAMWORK', 'COMMUNICATION', 'PROBLEM_SOLVING'],
+          now,
+        ],
+      );
+    }
+
+    // Student skills
+    const skillSets: Array<Array<[string, string, number]>> = [
+      [
+        ['TypeScript', 'ADVANCED', 18],
+        ['Node.js', 'ADVANCED', 12],
+        ['React', 'INTERMEDIATE', 8],
+      ],
+      [
+        ['Java', 'INTERMEDIATE', 12],
+        ['Spring Boot', 'INTERMEDIATE', 6],
+      ],
+      [
+        ['Python', 'ADVANCED', 24],
+        ['TensorFlow', 'ADVANCED', 18],
+        ['PyTorch', 'INTERMEDIATE', 12],
+      ],
+      [
+        ['Python', 'ADVANCED', 20],
+        ['scikit-learn', 'INTERMEDIATE', 10],
+        ['TypeScript', 'BEGINNER', 3],
+      ],
+      [
+        ['React', 'ADVANCED', 18],
+        ['React Native', 'INTERMEDIATE', 8],
+        ['CSS', 'ADVANCED', 24],
+      ],
+      [
+        ['Python', 'ADVANCED', 20],
+        ['Keras', 'INTERMEDIATE', 8],
+      ],
+      [
+        ['Python', 'ADVANCED', 16],
+        ['Docker', 'INTERMEDIATE', 10],
+        ['Kubernetes', 'BEGINNER', 4],
+      ],
+      [
+        ['Vue.js', 'INTERMEDIATE', 12],
+        ['TypeScript', 'INTERMEDIATE', 8],
+      ],
+      [
+        ['Go', 'ADVANCED', 24],
+        ['Docker', 'ADVANCED', 18],
+        ['PostgreSQL', 'ADVANCED', 20],
+      ],
+      [
+        ['Figma', 'INTERMEDIATE', 12],
+        ['Jira', 'INTERMEDIATE', 10],
+      ],
+      [
+        ['TypeScript', 'ADVANCED', 20],
+        ['NestJS', 'INTERMEDIATE', 10],
+        ['React', 'INTERMEDIATE', 12],
+      ],
+      [
+        ['Python', 'INTERMEDIATE', 14],
+        ['TensorFlow', 'BEGINNER', 6],
+      ],
+      [
+        ['React', 'INTERMEDIATE', 10],
+        ['React Native', 'BEGINNER', 4],
+      ],
+      [
+        ['Notion', 'ADVANCED', 20],
+        ['Figma', 'ADVANCED', 14],
+        ['Excel', 'ADVANCED', 36],
+      ],
+      [
+        ['TypeScript', 'INTERMEDIATE', 10],
+        ['Node.js', 'BEGINNER', 4],
+      ],
+    ];
+
+    for (let i = 0; i < students.length; i++) {
+      const spId = spIds[i];
+      for (const [name, level, months] of skillSets[i]) {
+        await client.query(
+          `INSERT INTO "StudentSkill" (id, "studentProfileId", name, level, "experienceMonths", "isPrimary", "createdAt", "updatedAt")
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+           ON CONFLICT DO NOTHING`,
+          [randomUUID(), spId, name, level, months, months >= 18, now],
+        );
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Teams
+    // -----------------------------------------------------------------------
+    const teams = [
+      { id: IDS.teamAlpha, name: 'Team Alpha', leaderId: IDS.student01 },
+      { id: IDS.teamBeta, name: 'Team Beta', leaderId: IDS.student04 },
+      { id: IDS.teamGamma, name: 'Team Gamma', leaderId: IDS.student06 },
+      { id: IDS.teamDelta, name: 'Team Delta', leaderId: IDS.student09 },
+      { id: IDS.teamEpsilon, name: 'Team Epsilon', leaderId: IDS.student11 },
+    ];
+
+    for (const t of teams) {
+      await client.query(
+        `INSERT INTO "Team" (id, name, "leaderId", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4, $4)
+         ON CONFLICT (id) DO NOTHING`,
+        [t.id, t.name, t.leaderId, now],
+      );
+    }
+
+    // Team memberships
+    const memberships: Array<[string, string]> = [
+      [IDS.student01, IDS.teamAlpha],
+      [IDS.student02, IDS.teamAlpha],
+      [IDS.student03, IDS.teamAlpha],
+      [IDS.student04, IDS.teamBeta],
+      [IDS.student05, IDS.teamBeta],
+      [IDS.student06, IDS.teamGamma],
+      [IDS.student07, IDS.teamGamma],
+      [IDS.student08, IDS.teamGamma],
+      [IDS.student09, IDS.teamDelta],
+      [IDS.student10, IDS.teamDelta],
+      [IDS.student11, IDS.teamEpsilon],
+      [IDS.student12, IDS.teamEpsilon],
+    ];
+
+    for (const [userId, teamId] of memberships) {
+      await client.query(
+        `INSERT INTO "TeamMember" ("userId", "teamId") VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [userId, teamId],
+      );
+    }
+
+    // -----------------------------------------------------------------------
+    // Backlog items (9 items across all statuses)
+    // -----------------------------------------------------------------------
+    const ownerTechNovaDbId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "User" WHERE email = 'owner@technova.dev.local' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const ownerGreenDbId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "User" WHERE email = 'owner@green.dev.local' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const ownerDataDbId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "User" WHERE email = 'owner@data.dev.local' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const ownerStartupDbId = (
+      await client.query<{ id: string }>(
+        `SELECT id FROM "User" WHERE email = 'owner@startup.dev.local' LIMIT 1`,
+      )
+    ).rows[0].id;
+
+    const backlogItems = [
+      {
+        id: IDS.backlog01,
+        orgId: orgTechNovaId,
+        poId: ownerTechNovaDbId,
+        status: 'IN_REALIZATION',
+        title: 'Automatizovaný onboarding systém pre zamestnancov',
+        description:
+          'Vybudovať komplexný self-service portál, ktorý prevedie nových zamestnancov celým procesom nástupu: od podpisu zmlúv cez školenia až po pridelenie prístupov. Integrácia s HR systémom a Active Directory.',
+        budget: 9500,
+        expectedOutcomes:
+          'Funkčný portál, integrácia s AD, automatické posielanie dokumentov, admin dashboard pre HR, pokrytie testami ≥ 75 %.',
+      },
+      {
+        id: IDS.backlog02,
+        orgId: orgTechNovaId,
+        poId: ownerTechNovaDbId,
+        status: 'ASSIGNED',
+        title: 'AI asistent pre zákaznícku podporu',
+        description:
+          'Integrovať LLM-based chatbota do existujúcej support platformy. Chatbot má zvládnuť tier-1 otázky, napojiť sa na CRM a automaticky eskalovať komplexné prípady ľudskému agentovi.',
+        budget: 8000,
+        expectedOutcomes:
+          'Fungujúci chatbot prototyp, CRM integrácia, handoff workflow, testy ≥ 70 %.',
+      },
+      {
+        id: IDS.backlog03,
+        orgId: orgGreenId,
+        poId: ownerGreenDbId,
+        status: 'IN_PAIRING',
+        title: 'Dashboard pre monitorovanie spotreby energie',
+        description:
+          'Vytvoriť real-time dashboard, ktorý agreguje dáta zo smart meračov a zobrazuje spotrebu energie na úrovni budovy, poschodia a miestnosti. Upozornenia pri anomáliách.',
+        budget: 6000,
+        expectedOutcomes:
+          'Real-time dashboard, IoT integrácia, email/SMS alerting, mobilne responzívne UI.',
+      },
+      {
+        id: IDS.backlog04,
+        orgId: orgGreenId,
+        poId: ownerGreenDbId,
+        status: 'IN_PAIRING',
+        title: 'Mobilná aplikácia pre komunitné záhrady',
+        description:
+          'Aplikácia pre správu komunitných záhrad: rezervácia záhonov, plán zavlažovania, zdieľanie sklizne a diskusné fórum pre pestovateľov.',
+        budget: 5500,
+        expectedOutcomes:
+          'iOS + Android app (React Native), backend API, push notifikácie, offline podpora.',
+      },
+      {
+        id: IDS.backlog05,
+        orgId: orgDataId,
+        poId: ownerDataDbId,
+        status: 'PUBLISHED',
+        title: 'Automatická generácia reportov z ERP dát',
+        description:
+          'Napojiť sa na SAP ERP API, transformovať dáta a generovať PDF/Excel reporty podľa šablón. Reporty sa posielajú emailom podľa nastaveného rozvrhu.',
+        budget: 7000,
+        expectedOutcomes:
+          'Konektory pre SAP, engine na šablóny, PDF/Excel export, scheduler, audit log.',
+      },
+      {
+        id: IDS.backlog06,
+        orgId: orgDataId,
+        poId: ownerDataDbId,
+        status: 'PUBLISHED',
+        title: 'Prediktívna analytika pre inventory management',
+        description:
+          'Vyvinúť ML model na predikciu dopytu a optimalizáciu zásob. Model sa napojí na existujúci skladový systém a bude generovať odporúčania na objednávanie.',
+        budget: 11000,
+        expectedOutcomes:
+          'Trénovaný model (MAPE < 15 %), REST API, integrácia so skladovým systémom, monitoring dashboard.',
+      },
+      {
+        id: IDS.backlog07,
+        orgId: orgStartupId,
+        poId: ownerStartupDbId,
+        status: 'PUBLISHED',
+        title: 'P2P platforma pre mikropôžičky',
+        description:
+          'Fintech platforma spájajúca veriteľov a dlžníkov pre krátkodobé mikropôžičky. Zahŕňa KYC verifikáciu, scoring model a escrow platobný systém.',
+        budget: 15000,
+        expectedOutcomes:
+          'KYC flow, credit scoring modul, escrow integrácia, admin panel pre compliance, GDPR compliance.',
+      },
+      {
+        id: IDS.backlog08,
+        orgId: orgTechNovaId,
+        poId: ownerTechNovaDbId,
+        status: 'DRAFT',
+        title: 'Interný knowledge base s AI vyhľadávaním',
+        description:
+          'Vybudovať internú wiki s AI-powered vyhľadávaním (RAG), kde zamestnanci môžu zdieľať znalosti, postupy a dokumentáciu. Integrácia so Slack-om.',
+        budget: 8500,
+        expectedOutcomes:
+          'Wiki s verzionovaním, RAG vyhľadávanie, Slack bot, roly a oprávnenia, analytics.',
+      },
+      {
+        id: IDS.backlog09,
+        orgId: orgGreenId,
+        poId: ownerGreenDbId,
+        status: 'CLOSED',
+        title: 'Web scraper pre monitoring cien energií',
+        description:
+          'Automatizovaný scraper, ktorý zbiera ceny elektriny a plynu z verejných zdrojov a ukladá ich do databázy pre ďalšiu analýzu.',
+        budget: 3000,
+        expectedOutcomes:
+          'Funkčný scraper, databáza s históriou cien, REST API, denné automatické spustenie.',
+      },
+    ];
+
+    for (const item of backlogItems) {
+      await client.query(
+        `INSERT INTO "BacklogItem" (id, "organizationId", "productOwnerUserId", title, description, budget, "expectedOutcomes", status, "createdAt", "updatedAt")
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9)
+         ON CONFLICT (id) DO NOTHING`,
+        [
+          item.id,
+          item.orgId,
+          item.poId,
+          item.title,
+          item.description,
+          item.budget,
+          item.expectedOutcomes,
+          item.status,
+          now,
+        ],
+      );
+    }
+
+    // -----------------------------------------------------------------------
+    // Program B — Team Applications
+    // -----------------------------------------------------------------------
+    const pbApps = [
+      // Team Alpha → Backlog01 (IN_REALIZATION) — PROJECT_CREATED
+      {
+        id: IDS.pbApp01,
+        backlogItemId: IDS.backlog01,
+        teamId: IDS.teamAlpha,
+        createdById: IDS.student01,
+        status: 'PROJECT_CREATED',
+        motivation:
+          'Náš tím má silné skúsenosti s NestJS a PostgreSQL. Tento projekt nám dá príležitosť aplikovať poznatky z praxe na reálny HR problém.',
+        acceptedAt: new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000),
+      },
+      // Team Beta → Backlog02 (ASSIGNED) — ACCEPTED
+      {
+        id: IDS.pbApp02,
+        backlogItemId: IDS.backlog02,
+        teamId: IDS.teamBeta,
+        createdById: IDS.student04,
+        status: 'ACCEPTED',
+        motivation:
+          'Zaujíma nás práca s LLM a integrácia AI do produktov. Máme skúsenosti s Pythonom a MLOps.',
+        acceptedAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000),
+      },
+      // Team Gamma → Backlog03 (IN_PAIRING) — SHORTLISTED
+      {
+        id: IDS.pbApp03,
+        backlogItemId: IDS.backlog03,
+        teamId: IDS.teamGamma,
+        createdById: IDS.student06,
+        status: 'SHORTLISTED',
+        motivation:
+          'Tím sa zaujíma o IoT a vizualizáciu dát v reálnom čase. Máme skúsenosti s React a WebSocket.',
+        shortlistedAt: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000),
+      },
+      // Team Delta → Backlog04 (IN_PAIRING) — SUBMITTED
+      {
+        id: IDS.pbApp04,
+        backlogItemId: IDS.backlog04,
+        teamId: IDS.teamDelta,
+        createdById: IDS.student09,
+        status: 'SUBMITTED',
+        motivation:
+          'Mobilný development je naša silná stránka. Navrhneme offline-first architektúru s React Native.',
+        shortlistedAt: null,
+      },
+      // Another team applies to Backlog03 — SUBMITTED (competing application)
+      {
+        id: IDS.pbApp05,
+        backlogItemId: IDS.backlog03,
+        teamId: IDS.teamEpsilon,
+        createdById: IDS.student11,
+        status: 'SUBMITTED',
+        motivation:
+          'Sme tím backendových a DevOps vývojárov. IoT integráciu zvládneme cez MQTT broker a Kubernetes.',
+        shortlistedAt: null,
+      },
+    ];
+
+    for (const app of pbApps) {
+      await client.query(
+        `INSERT INTO "ProgramBTeamApplication" (
+          id, "backlogItemId", "teamId", "createdById", motivation, status,
+          "submittedAt", "shortlistedAt", "acceptedAt", "createdAt", "updatedAt"
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10)
+        ON CONFLICT (id) DO NOTHING`,
+        [
+          app.id,
+          app.backlogItemId,
+          app.teamId,
+          app.createdById,
+          app.motivation,
+          app.status,
+          now,
+          app.shortlistedAt ?? null,
+          (app as { acceptedAt?: Date }).acceptedAt ?? null,
+          now,
+        ],
+      );
+    }
+
+    // -----------------------------------------------------------------------
+    // Program B — Projects
+    // -----------------------------------------------------------------------
+
+    // Project 1: Team Alpha on Backlog01 — ACTIVE (IN_REALIZATION, has mentor)
+    await client.query(
+      `INSERT INTO "ProgramBProject" (
+        id, "backlogItemId", "teamApplicationId", "teamId",
+        "productOwnerUserId", "mentorUserId", "mentorAssignedAt", "mentorAssignedById",
+        status, "acceptedByCompanyAt", "acceptedByNtiAt", "createdAt", "updatedAt"
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$12)
+      ON CONFLICT (id) DO NOTHING`,
+      [
+        IDS.pbProject01,
+        IDS.backlog01,
+        IDS.pbApp01,
+        IDS.teamAlpha,
+        ownerTechNovaDbId,
+        IDS.mentor1,
+        new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000),
+        IDS.admin1,
+        'ACTIVE',
+        new Date(now.getTime() - 18 * 24 * 60 * 60 * 1000),
+        new Date(now.getTime() - 17 * 24 * 60 * 60 * 1000),
+        now,
+      ],
+    );
+
+    // Milestones for Project 1
+    const pbMilestones = [
+      {
+        title: 'Analýza požiadaviek a ER diagram',
+        status: 'DONE',
+        dueAt: new Date(now.getTime() - 12 * 24 * 60 * 60 * 1000),
+      },
+      {
+        title: 'Backend API (NestJS + Prisma)',
+        status: 'IN_PROGRESS',
+        dueAt: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000),
+      },
+      {
+        title: 'Frontend integrácia',
+        status: 'PLANNED',
+        dueAt: new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000),
+      },
+      {
+        title: 'AD integrácia',
+        status: 'PLANNED',
+        dueAt: new Date(now.getTime() + 21 * 24 * 60 * 60 * 1000),
+      },
+      {
+        title: 'Testovanie a odovzdanie',
+        status: 'PLANNED',
+        dueAt: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+      },
+    ];
+
+    for (const m of pbMilestones) {
+      await client.query(
+        `INSERT INTO "ProgramBMilestone" (id, "projectId", title, status, "dueAt", "createdAt", "updatedAt")
+         VALUES ($1,$2,$3,$4,$5,$6,$6)
+         ON CONFLICT (id) DO NOTHING`,
+        [randomUUID(), IDS.pbProject01, m.title, m.status, m.dueAt, now],
+      );
+    }
+
+    // Mentoring notes for Project 1
+    const mentoringNotes = [
+      'Tím má dobrý základ, ale treba spresniť API kontrakt pred implementáciou frontendu.',
+      'Databázová schéma je dobre navrhnutá. Odporúčam pridať indexy na FK stĺpce.',
+      'Pokrok je solídny. Na budúcom stretnutí sa pozrieme na integračné testy.',
+    ];
+
+    for (const note of mentoringNotes) {
+      await client.query(
+        `INSERT INTO "ProgramBMentoringNote" (id, "projectId", "authorUserId", note, "createdAt")
+         VALUES ($1,$2,$3,$4,$5)
+         ON CONFLICT (id) DO NOTHING`,
+        [randomUUID(), IDS.pbProject01, IDS.mentor1, note, now],
+      );
+    }
+
+    // PO reviews for Project 1
+    await client.query(
+      `INSERT INTO "ProgramBPoReview" (id, "projectId", "authorUserId", decision, comment, "createdAt")
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        randomUUID(),
+        IDS.pbProject01,
+        ownerTechNovaDbId,
+        'APPROVED',
+        'Prvý míľnik splnený. Analýza požiadaviek je kompletná a ER diagram zodpovedá špecifikácii.',
+        now,
+      ],
+    );
+
+    // Project 2: Team Beta on Backlog02 — ACTIVE (newly accepted, no mentor yet)
+    await client.query(
+      `INSERT INTO "ProgramBProject" (
+        id, "backlogItemId", "teamApplicationId", "teamId",
+        "productOwnerUserId", status, "acceptedByCompanyAt", "createdAt", "updatedAt"
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$8)
+      ON CONFLICT (id) DO NOTHING`,
+      [
+        IDS.pbProject02,
+        IDS.backlog02,
+        IDS.pbApp02,
+        IDS.teamBeta,
+        ownerTechNovaDbId,
+        'ACTIVE',
+        new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000),
+        now,
+      ],
+    );
+
+    // -----------------------------------------------------------------------
+    // Program A — Applications (5 teams, various statuses)
+    // -----------------------------------------------------------------------
+    const programACallRow = await client.query<{ id: string }>(
+      `SELECT id FROM "Call" WHERE type = 'PROGRAM_A' LIMIT 1`,
+    );
+    const programACallId = programACallRow.rows[0]?.id;
+
+    if (programACallId) {
+      const paApps = [
+        // Team Alpha — ACTIVE_PROJECT (approved, mentor assigned, has milestones)
+        {
+          id: IDS.paApp01,
+          teamId: IDS.teamAlpha,
+          createdById: IDS.student01,
+          status: 'ACTIVE_PROJECT',
+          mentorUserId: IDS.mentor2,
+          submittedAt: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+          decidedAt: new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000),
+          decisionById: IDS.admin1,
+          decisionRationale:
+            'Silný tím s jasnou víziou produktu a technickým zázemím.',
+        },
+        // Team Beta — EVALUATING (has evaluations)
+        {
+          id: IDS.paApp02,
+          teamId: IDS.teamBeta,
+          createdById: IDS.student04,
+          status: 'EVALUATING',
+          submittedAt: new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000),
+          decidedAt: null,
+          decisionById: null,
+          decisionRationale: null,
+          mentorUserId: null,
+        },
+        // Team Gamma — NEEDS_INFO (has open needs-info item)
+        {
+          id: IDS.paApp03,
+          teamId: IDS.teamGamma,
+          createdById: IDS.student06,
+          status: 'NEEDS_INFO',
+          submittedAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000),
+          decidedAt: null,
+          decisionById: null,
+          decisionRationale: null,
+          mentorUserId: null,
+        },
+        // Team Delta — SUBMITTED
+        {
+          id: IDS.paApp04,
+          teamId: IDS.teamDelta,
+          createdById: IDS.student09,
+          status: 'SUBMITTED',
+          submittedAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000),
+          decidedAt: null,
+          decisionById: null,
+          decisionRationale: null,
+          mentorUserId: null,
+        },
+        // Team Epsilon — DRAFT
+        {
+          id: IDS.paApp05,
+          teamId: IDS.teamEpsilon,
+          createdById: IDS.student11,
+          status: 'DRAFT',
+          submittedAt: null,
+          decidedAt: null,
+          decisionById: null,
+          decisionRationale: null,
+          mentorUserId: null,
+        },
+      ];
+
+      for (const app of paApps) {
+        await client.query(
+          `INSERT INTO "Application" (
+            id, "callId", "teamId", "createdById", status,
+            "submittedAt", "decidedAt", "decisionById", "decisionRationale",
+            "mentorUserId", "mentorAssignedAt", "mentorAssignedById",
+            "createdAt", "updatedAt"
+          ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$13)
+          ON CONFLICT (id) DO NOTHING`,
+          [
+            app.id,
+            programACallId,
+            app.teamId,
+            app.createdById,
+            app.status,
+            app.submittedAt,
+            app.decidedAt,
+            app.decisionById,
+            app.decisionRationale,
+            app.mentorUserId ?? null,
+            app.mentorUserId
+              ? new Date(now.getTime() - 18 * 24 * 60 * 60 * 1000)
+              : null,
+            app.mentorUserId ? IDS.admin1 : null,
+            now,
+          ],
+        );
+      }
+
+      // Evaluations for Team Beta application
+      const evaluationCriteria = [
+        'innovation',
+        'technical_feasibility',
+        'team_quality',
+        'market_potential',
+      ];
+
+      for (const [evalId, evaluatorId, recommendation, comment, scores] of [
+        [
+          randomUUID(),
+          IDS.evaluator1,
+          'APPROVE',
+          'Silný návrh s jasnou hodnotovou ponukou. Tím má relevantné skúsenosti.',
+          [4, 4, 5, 4],
+        ],
+        [
+          randomUUID(),
+          IDS.evaluator2,
+          'NEEDS_INFO',
+          'Inovatívny prístup, ale finančný plán je nejasný. Potrebujeme viac detailov.',
+          [5, 3, 4, 3],
+        ],
+      ] as const) {
+        await client.query(
+          `INSERT INTO "ApplicationEvaluation" (id, "applicationId", "evaluatorId", recommendation, comment, "createdAt", "updatedAt")
+           VALUES ($1,$2,$3,$4,$5,$6,$6)
+           ON CONFLICT ("applicationId", "evaluatorId") DO NOTHING`,
+          [evalId, IDS.paApp02, evaluatorId, recommendation, comment, now],
+        );
+
+        const evalDbRow = await client.query<{ id: string }>(
+          `SELECT id FROM "ApplicationEvaluation" WHERE "applicationId" = $1 AND "evaluatorId" = $2 LIMIT 1`,
+          [IDS.paApp02, evaluatorId],
+        );
+        const evalDbId = evalDbRow.rows[0]?.id;
+        if (evalDbId) {
+          for (let i = 0; i < evaluationCriteria.length; i++) {
+            await client.query(
+              `INSERT INTO "ApplicationEvaluationScore" (id, "evaluationId", "criterionCode", score)
+               VALUES ($1,$2,$3,$4)
+               ON CONFLICT ("evaluationId", "criterionCode") DO NOTHING`,
+              [randomUUID(), evalDbId, evaluationCriteria[i], scores[i]],
+            );
+          }
+        }
+      }
+
+      // NeedsInfo item for Team Gamma application
+      await client.query(
+        `INSERT INTO "NeedsInfoItem" (id, "applicationId", message, "dueAt", status, "createdById", "createdAt")
+         VALUES ($1,$2,$3,$4,$5,$6,$7)
+         ON CONFLICT (id) DO NOTHING`,
+        [
+          randomUUID(),
+          IDS.paApp03,
+          'Prosíme o doplnenie podrobného finančného plánu na celú dobu realizácie projektu vrátane rozdelenia nákladov na jednotlivé míľniky.',
+          new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+          'OPEN',
+          IDS.admin1,
+          now,
+        ],
+      );
+
+      // Status events for Team Alpha application (transition history)
+      const alphaStatusHistory = [
+        {
+          from: 'DRAFT',
+          to: 'SUBMITTED',
+          by: IDS.student01,
+          at: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+        },
+        {
+          from: 'SUBMITTED',
+          to: 'FORMALLY_VERIFIED',
+          by: IDS.admin1,
+          at: new Date(now.getTime() - 28 * 24 * 60 * 60 * 1000),
+        },
+        {
+          from: 'FORMALLY_VERIFIED',
+          to: 'EVALUATING',
+          by: IDS.admin1,
+          at: new Date(now.getTime() - 25 * 24 * 60 * 60 * 1000),
+        },
+        {
+          from: 'EVALUATING',
+          to: 'APPROVED',
+          by: IDS.admin1,
+          at: new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000),
+        },
+        {
+          from: 'APPROVED',
+          to: 'ONBOARDING',
+          by: IDS.admin1,
+          at: new Date(now.getTime() - 18 * 24 * 60 * 60 * 1000),
+        },
+        {
+          from: 'ONBOARDING',
+          to: 'ACTIVE_PROJECT',
+          by: IDS.admin1,
+          at: new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000),
+        },
+      ];
+
+      for (const ev of alphaStatusHistory) {
+        await client.query(
+          `INSERT INTO "ApplicationStatusEvent" (id, "applicationId", "fromStatus", "toStatus", "changedById", "createdAt")
+           VALUES ($1,$2,$3,$4,$5,$6)
+           ON CONFLICT (id) DO NOTHING`,
+          [randomUUID(), IDS.paApp01, ev.from, ev.to, ev.by, ev.at],
+        );
+      }
+
+      // Program A milestones for Team Alpha
+      const paMilestones = [
+        {
+          title: 'Kick-off a definícia MVP',
+          status: 'DONE',
+          dueAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000),
+        },
+        {
+          title: 'Prototyp a používateľské testovanie',
+          status: 'IN_PROGRESS',
+          dueAt: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+        },
+        {
+          title: 'Beta verzia',
+          status: 'PLANNED',
+          dueAt: new Date(now.getTime() + 21 * 24 * 60 * 60 * 1000),
+        },
+        {
+          title: 'Finálne odovzdanie',
+          status: 'PLANNED',
+          dueAt: new Date(now.getTime() + 42 * 24 * 60 * 60 * 1000),
+        },
+      ];
+
+      for (const m of paMilestones) {
+        await client.query(
+          `INSERT INTO "ProgramAMilestone" (id, "applicationId", title, status, "dueAt", "createdAt", "updatedAt")
+           VALUES ($1,$2,$3,$4,$5,$6,$6)
+           ON CONFLICT (id) DO NOTHING`,
+          [randomUUID(), IDS.paApp01, m.title, m.status, m.dueAt, now],
+        );
+      }
+
+      // Mentorship notes for Team Alpha
+      for (const note of [
+        'Tím je motivovaný a má jasnú predstavu o produkte. Odporúčam zamerať sa na validáciu s potenciálnymi používateľmi čo najskôr.',
+        'Pokrok na prototypu je solídny. Treba dokončiť user testing pred prechodom na beta fázu.',
+      ]) {
+        await client.query(
+          `INSERT INTO "ProgramAMentorshipNote" (id, "applicationId", "authorId", content, "createdAt")
+           VALUES ($1,$2,$3,$4,$5)
+           ON CONFLICT (id) DO NOTHING`,
+          [randomUUID(), IDS.paApp01, IDS.mentor2, note, now],
+        );
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Summary
+    // -----------------------------------------------------------------------
+    console.info('[seed] dev fixtures created successfully');
+    console.info('[seed] --- DEV ACCOUNTS (password: Dev1234!) ---');
+    console.info('[seed] admin1@dev.local / admin2@dev.local  — ADMIN');
+    console.info(
+      '[seed] mentor1@dev.local / mentor2@dev.local / mentor3@dev.local  — MENTOR',
+    );
+    console.info(
+      '[seed] evaluator1@dev.local / evaluator2@dev.local  — EVALUATOR',
+    );
+    console.info('[seed] editor1@dev.local  — CONTENT_EDITOR');
+    console.info(
+      '[seed] owner@technova.dev.local / employee@technova.dev.local  — TechNova s.r.o.',
+    );
+    console.info('[seed] owner@green.dev.local  — GreenSolutions a.s.');
+    console.info('[seed] owner@data.dev.local  — DataDriven s.r.o.');
+    console.info('[seed] owner@startup.dev.local  — StartupXYZ s.r.o.');
+    console.info(
+      '[seed] student01@dev.local ... student15@dev.local  — STUDENT',
+    );
+  },
+};

--- a/src/applications/calls.repository.ts
+++ b/src/applications/calls.repository.ts
@@ -461,6 +461,17 @@ export class CallsRepository extends BaseRepository<
     } as const;
   }
 
+  hasActiveProgramBCall(now: Date, db?: PrismaDbClient): Promise<boolean> {
+    return (db ?? this.prisma.client).call
+      .count({
+        where: {
+          type: ProgramType.PROGRAM_B,
+          ...this.buildPublicVisibleWhere(now),
+        },
+      })
+      .then((count) => count > 0);
+  }
+
   private buildPublicVisibleWhere(at: Date): Prisma.CallWhereInput {
     return {
       status: CallStatus.OPEN,

--- a/src/programs/program-b/backlog/program-b-backlog.module.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.module.ts
@@ -4,6 +4,7 @@ import { FilesModule } from '../../../files';
 import { StorageModule } from '../../../infrastructure/storage';
 import { OrganizationRepository } from '../../../organization/organization.repository';
 import { UserRepository } from '../../../user/user.repository';
+import { CallsRepository } from '../../../applications/calls.repository';
 import { ProgramBProjectsRepository } from '../projects/program-b-projects.repository';
 import { ProgramBTeamApplicationRepository } from '../team-application/program-b-team-application.repository';
 import { ProgramBBacklogController } from './program-b-backlog.controller';
@@ -18,6 +19,7 @@ import { ProgramBBacklogService } from './program-b-backlog.service';
     ProgramBBacklogRepository,
     OrganizationRepository,
     UserRepository,
+    CallsRepository,
     ProgramBTeamApplicationRepository,
     ProgramBProjectsRepository,
   ],

--- a/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.spec.ts
@@ -304,6 +304,7 @@ describe('ProgramBBacklogService', () => {
       projectsRepository as never,
       filesService as never,
       storageService as never,
+      { hasActiveProgramBCall: jest.fn().mockResolvedValue(true) } as never,
     );
   });
 
@@ -490,6 +491,52 @@ describe('ProgramBBacklogService', () => {
     await expect(
       service.create({ productOwnerUserId: 'other-org-user' }, owner as never),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('returns an empty page for listPublished when no active call exists', async () => {
+    const callsRepository = {
+      hasActiveProgramBCall: jest.fn().mockResolvedValue(false),
+    };
+    const localService = new ProgramBBacklogService(
+      backlogRepository as never,
+      organizationRepository as never,
+      userRepository as never,
+      teamApplicationRepository as never,
+      projectsRepository as never,
+      filesService as never,
+      storageService as never,
+      callsRepository as never,
+    );
+
+    const result = await localService.listPublished(
+      { page: 1, limit: 20, sort: 'updatedAt', order: 'desc' },
+      student as never,
+    );
+
+    expect(result.data).toEqual([]);
+    expect(result.meta.total).toBe(0);
+    expect(backlogRepository.findMany).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException for findPublishedById when no active call exists', async () => {
+    const callsRepository = {
+      hasActiveProgramBCall: jest.fn().mockResolvedValue(false),
+    };
+    const localService = new ProgramBBacklogService(
+      backlogRepository as never,
+      organizationRepository as never,
+      userRepository as never,
+      teamApplicationRepository as never,
+      projectsRepository as never,
+      filesService as never,
+      storageService as never,
+      callsRepository as never,
+    );
+    backlogRepository.findDetailUnique.mockResolvedValue(publishedItem);
+
+    await expect(
+      localService.findPublishedById('item-1', student as never),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('lists organization backlog items with deterministic sorting', async () => {

--- a/src/programs/program-b/backlog/program-b-backlog.service.ts
+++ b/src/programs/program-b/backlog/program-b-backlog.service.ts
@@ -18,6 +18,7 @@ import {
   UserRole,
   UserStatus,
 } from '../../../../generated/prisma/enums';
+import { CallsRepository } from '../../../applications/calls.repository';
 import { isPrismaUniqueConstraintError } from '../../../common/prisma/prisma-error.utils';
 import type { AuthenticatedUserContext } from '../../../common/types/auth-user-context.type';
 import {
@@ -65,6 +66,7 @@ export class ProgramBBacklogService {
     private readonly projectsRepository: ProgramBProjectsRepository,
     private readonly filesService: FilesService,
     private readonly storageService: R2StorageService,
+    private readonly callsRepository: CallsRepository,
   ) {}
 
   async create(
@@ -208,6 +210,15 @@ export class ProgramBBacklogService {
     this.ensureActiveStudent(user);
 
     const pagination = resolvePagination(query);
+    const hasActiveCall = await this.callsRepository.hasActiveProgramBCall(
+      new Date(),
+    );
+    if (!hasActiveCall) {
+      return {
+        data: [],
+        meta: buildPaginationMeta(0, pagination.page, pagination.limit),
+      };
+    }
     const normalizedQuery = query.q?.trim();
     const where: Prisma.BacklogItemWhereInput = {
       status: BacklogItemStatus.PUBLISHED,
@@ -256,9 +267,17 @@ export class ProgramBBacklogService {
     user: AuthenticatedUserContext,
   ): Promise<ProgramBBacklogItemDto> {
     this.ensureActiveStudent(user);
-    const item = await this.backlogRepository.findDetailUnique({ id });
 
-    if (!item || item.status !== BacklogItemStatus.PUBLISHED) {
+    const [item, hasActiveCall] = await Promise.all([
+      this.backlogRepository.findDetailUnique({ id }),
+      this.callsRepository.hasActiveProgramBCall(new Date()),
+    ]);
+
+    if (
+      !item ||
+      item.status !== BacklogItemStatus.PUBLISHED ||
+      !hasActiveCall
+    ) {
       throw new NotFoundException('Backlog item not found');
     }
 

--- a/src/programs/program-b/projects/dto/program-b-assignable-mentor.dto.ts
+++ b/src/programs/program-b/projects/dto/program-b-assignable-mentor.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProgramBAssignableMentorDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  firstName!: string;
+
+  @ApiProperty()
+  lastName!: string;
+
+  @ApiProperty()
+  email!: string;
+}

--- a/src/programs/program-b/projects/program-b-projects.controller.ts
+++ b/src/programs/program-b/projects/program-b-projects.controller.ts
@@ -19,6 +19,7 @@ import { RolesGuard } from '../../../auth/guards/roles.guard';
 import type { AuthenticatedUserContext } from '../../../common/types/auth-user-context.type';
 import { CompleteProgramBDocumentUploadDto } from '../backlog/dto/complete-program-b-document-upload.dto';
 import { ProgramBDocumentDownloadDto } from '../backlog/dto/program-b-backlog-document.dto';
+import { ProgramBAssignableMentorDto } from './dto/program-b-assignable-mentor.dto';
 import { AssignProgramBMentorDto } from './dto/assign-program-b-mentor.dto';
 import { CreateProgramBFinalAcceptanceDto } from './dto/create-program-b-final-acceptance.dto';
 import { CreateProgramBMentoringNoteDto } from './dto/create-program-b-mentoring-note.dto';
@@ -57,6 +58,13 @@ export class ProgramBProjectsController {
   )
   listMy(@GetUserContext() user: AuthenticatedUserContext) {
     return this.projectsService.listMy(user);
+  }
+
+  @ApiOkResponse({ type: [ProgramBAssignableMentorDto] })
+  @Get('assignable-mentors')
+  @Roles(UserRole.EVALUATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  listAssignableMentors(@GetUserContext() user: AuthenticatedUserContext) {
+    return this.projectsService.listAssignableMentors(user);
   }
 
   @ApiOkResponse({ type: ProgramBProjectDetailDto })

--- a/src/programs/program-b/projects/program-b-projects.service.ts
+++ b/src/programs/program-b/projects/program-b-projects.service.ts
@@ -23,6 +23,7 @@ import { FilesService } from '../../../files';
 import { UserRepository } from '../../../user/user.repository';
 import { CompleteProgramBDocumentUploadDto } from '../backlog/dto/complete-program-b-document-upload.dto';
 import { ProgramBDocumentDownloadDto } from '../backlog/dto/program-b-backlog-document.dto';
+import { ProgramBAssignableMentorDto } from './dto/program-b-assignable-mentor.dto';
 import { AssignProgramBMentorDto } from './dto/assign-program-b-mentor.dto';
 import {
   CreateProgramBFinalAcceptanceDto,
@@ -389,6 +390,21 @@ export class ProgramBProjectsService {
 
       return this.toProjectDetailDto(updatedProject);
     }, this.projectWriteTransactionOptions);
+  }
+
+  async listAssignableMentors(
+    user: AuthenticatedUserContext,
+  ): Promise<ProgramBAssignableMentorDto[]> {
+    this.ensureMentorAssignmentAuthor(user);
+
+    const mentors = await this.userRepository.findActiveMentors();
+
+    return mentors.map((mentor) => ({
+      id: mentor.id,
+      firstName: mentor.firstName,
+      lastName: mentor.lastName,
+      email: mentor.email,
+    }));
   }
 
   async recordFinalAcceptance(

--- a/src/programs/program-b/team-application/program-b-team-application.module.ts
+++ b/src/programs/program-b/team-application/program-b-team-application.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { CallsRepository } from '../../../applications/calls.repository';
 import { ProgramBTeamApplicationService } from './program-b-team-application.service';
 import { ProgramBTeamApplicationController } from './program-b-team-application.controller';
 import { ProgramBTeamApplicationWithdrawalController } from './program-b-team-application-withdrawal.controller';
@@ -13,6 +14,7 @@ import { ProgramBTeamApplicationRepository } from './program-b-team-application.
   providers: [
     ProgramBTeamApplicationService,
     ProgramBTeamApplicationRepository,
+    CallsRepository,
   ],
   controllers: [
     ProgramBTeamApplicationController,

--- a/src/programs/program-b/team-application/program-b-team-application.service.ts
+++ b/src/programs/program-b/team-application/program-b-team-application.service.ts
@@ -5,6 +5,7 @@ import {
   ConflictException,
   BadRequestException,
 } from '@nestjs/common';
+import { CallsRepository } from '../../../applications/calls.repository';
 import { PrismaService } from '../../../infrastructure/database/prisma.service';
 import { CreateTeamApplicationDto } from './dto/create-team-application.dto';
 import {
@@ -32,6 +33,7 @@ export class ProgramBTeamApplicationService {
     private uploadedFileService: FilesService,
     private teamService: TeamService,
     private backlogItemService: ProgramBBacklogService,
+    private callsRepository: CallsRepository,
   ) {}
 
   async submitApplication(
@@ -39,9 +41,16 @@ export class ProgramBTeamApplicationService {
     backlogItemId: string,
     dto: CreateTeamApplicationDto,
   ): Promise<ApplicationWithCv> {
-    const backlogItem = await this.backlogItemService.findOne(backlogItemId);
+    const [backlogItem, hasActiveCall] = await Promise.all([
+      this.backlogItemService.findOne(backlogItemId),
+      this.callsRepository.hasActiveProgramBCall(new Date()),
+    ]);
+
     if (!backlogItem) {
       throw new NotFoundException('Backlog item not found');
+    }
+    if (!hasActiveCall) {
+      throw new ConflictException('No active Program B call');
     }
     if (backlogItem.status !== BacklogItemStatus.PUBLISHED) {
       throw new ConflictException('Backlog item must be published');
@@ -129,6 +138,14 @@ export class ProgramBTeamApplicationService {
     }
 
     return this.prisma.client.$transaction(async (tx) => {
+      const callStillActive = await this.callsRepository.hasActiveProgramBCall(
+        new Date(),
+        tx as never,
+      );
+      if (!callStillActive) {
+        throw new ConflictException('No active Program B call');
+      }
+
       const application = await tx.programBTeamApplication.create({
         data: {
           backlogItemId,

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -160,6 +160,17 @@ export class UserRepository extends BaseRepository<
     });
   }
 
+  findActiveMentors(db?: PrismaDbClient): Promise<OrganizationMemberRecord[]> {
+    return this.getDelegate(db).findMany({
+      where: {
+        role: UserRole.MENTOR,
+        status: UserStatus.ACTIVE,
+      },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+      select: organizationMemberSelect,
+    });
+  }
+
   updateUserRole(
     userId: string,
     role: UserRole,


### PR DESCRIPTION
- Add CallsRepository.hasActiveProgramBCall to check if a Program B call is currently open; used across backlog and team-application flows
- listPublished returns an empty page when no active call exists instead of querying the DB; findPublishedById returns 404
- submitApplication checks call status before item status (prevents leaking draft-item existence) and re-checks inside the transaction to close the TOCTOU window between preflight and insert
- Fix seed UPDATE to target the fetched row id (not WHERE type=…), add title to the updated columns, and use NOW() for updatedAt
- Add listAssignableMentors endpoint (EVALUATOR/ADMIN/SUPER_ADMIN) backed by UserRepository.findActiveMentors
- Add tests covering the no-active-call rejection paths for listPublished and findPublishedById