### PR TITLE
feat(applications): expose submitted team applications

### DIFF
--- a/src/applications/api-docs/applications-api-docs.decorators.ts
+++ b/src/applications/api-docs/applications-api-docs.decorators.ts
@@ -41,6 +41,7 @@ import { RequiredDocumentsResponseDto } from '../dto/required-documents-response
 import { ResubmitApplicationDto } from '../dto/resubmit-application.dto';
 import { SetActiveSectionVersionDto } from '../dto/set-active-section-version.dto';
 import { UpsertIdeaOverviewSectionDto } from '../dto/upsert-idea-overview-section.dto';
+import { StudentApplicationSummaryDto } from '../dto/student-application-summary.dto';
 
 export const CreateApplicationApi = () =>
   createApiDecorator({
@@ -67,6 +68,26 @@ export const CreateApplicationApi = () =>
       }),
       ApiNotFoundResponse({
         description: 'Related entities were not found.',
+      }),
+    ],
+  });
+
+export const ListSubmittedCurrentTeamApplicationsApi = () =>
+  createApiDecorator({
+    summary: 'List submitted applications for current team',
+    description:
+      'Returns submitted applications for the current student team so the dashboard can show application statuses and needs-info alerts.',
+    successResponse: {
+      status: 200,
+      type: StudentApplicationSummaryDto,
+      isArray: true,
+      description: 'Submitted applications for the current team.',
+    },
+    extraDecorators: [ApiBearerAuth('access-token')],
+    errors: [
+      ApiUnauthorizedResponse({ description: 'Authentication is required.' }),
+      ApiConflictResponse({
+        description: 'Current user has multiple active teams.',
       }),
     ],
   });

--- a/src/applications/api-docs/index.ts
+++ b/src/applications/api-docs/index.ts
@@ -32,4 +32,5 @@ export {
   StartApplicationOnboardingApi,
   SubmitApplicationApi,
   UpsertIdeaOverviewSectionApi,
+  ListSubmittedCurrentTeamApplicationsApi,
 } from './applications-api-docs.decorators';

--- a/src/applications/application.mappers.ts
+++ b/src/applications/application.mappers.ts
@@ -21,6 +21,7 @@ import { ApplicationEvaluationWithScores } from './evaluations/application-evalu
 import { ApplicationWithRelations } from './applications.repository';
 import { ProgramAMentorshipNoteWithAuthor } from '../programs/program-a/program-a-mentorship.repository';
 import { ProgramAMilestoneWithApplication } from '../programs/program-a/program-a-milestones.repository';
+import { StudentApplicationSummaryDto } from './dto/student-application-summary.dto';
 
 export function toDetailDto(
   application: ApplicationWithRelations,
@@ -168,6 +169,38 @@ export function toApplicationEvaluationDto(
     })),
     createdAt: evaluation.createdAt,
     updatedAt: evaluation.updatedAt,
+  };
+}
+
+export function toStudentApplicationSummaryDto(application: {
+  id: string;
+  callId: string;
+  teamId: string;
+  status: ApplicationStatus;
+  submittedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  call: {
+    id: string;
+    title: string;
+    type: ProgramType;
+    status: CallStatus;
+  };
+}): StudentApplicationSummaryDto {
+  return {
+    id: application.id,
+    callId: application.callId,
+    teamId: application.teamId,
+    status: application.status,
+    submittedAt: application.submittedAt,
+    createdAt: application.createdAt,
+    updatedAt: application.updatedAt,
+    call: {
+      id: application.call.id,
+      title: application.call.title,
+      type: application.call.type,
+      status: application.call.status,
+    },
   };
 }
 

--- a/src/applications/applications.controller.ts
+++ b/src/applications/applications.controller.ts
@@ -40,6 +40,7 @@ import {
   SetActiveSectionVersionApi,
   SubmitApplicationApi,
   UpsertIdeaOverviewSectionApi,
+  ListSubmittedCurrentTeamApplicationsApi,
 } from './api-docs';
 import { ApplicationDetailDto } from './dto/application-detail.dto';
 import { ApplicationDocumentDto } from './dto/application-document.dto';
@@ -75,6 +76,7 @@ import { ApplicationSectionsService } from './sections/application-sections.serv
 import { ApplicationsService } from './applications.service';
 import { ProgramAMentorshipService } from '../programs/program-a/program-a-mentorship.service';
 import { CallsService } from './calls/calls.service';
+import { StudentApplicationSummaryDto } from './dto/student-application-summary.dto';
 
 @ApiTags('Applications')
 @Controller('applications')
@@ -118,6 +120,15 @@ export class ApplicationsController {
     @Body() dto: CreateApplicationDto,
   ): Promise<ApplicationDetailDto> {
     return this.applicationsService.createDraft(user, dto);
+  }
+
+  @ListSubmittedCurrentTeamApplicationsApi()
+  @Get('team/current/submitted')
+  @UseGuards(JwtAuthGuard)
+  listSubmittedForCurrentTeam(
+    @GetUserContext() user: AuthenticatedUserContext,
+  ): Promise<StudentApplicationSummaryDto[]> {
+    return this.applicationsService.listSubmittedForCurrentTeam(user);
   }
 
   @GetApplicationApi()

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -120,6 +120,45 @@ export class ApplicationsRepository extends BaseRepository<
     });
   }
 
+  listSubmittedForTeam(teamId: string, db?: PrismaDbClient) {
+    return (db ?? this.prisma.client).application.findMany({
+      where: {
+        teamId,
+        submittedAt: {
+          not: null,
+        },
+        status: {
+          not: ApplicationStatus.DRAFT,
+        },
+      },
+      orderBy: [
+        {
+          submittedAt: 'desc',
+        },
+        {
+          createdAt: 'desc',
+        },
+      ],
+      select: {
+        id: true,
+        callId: true,
+        teamId: true,
+        status: true,
+        submittedAt: true,
+        createdAt: true,
+        updatedAt: true,
+        call: {
+          select: {
+            id: true,
+            title: true,
+            type: true,
+            status: true,
+          },
+        },
+      },
+    });
+  }
+
   createDraft(
     callId: string,
     teamId: string,

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -58,9 +58,11 @@ import {
   toInternalProgramAApplicationDto,
   toNeedsInfoItemDto,
   toNeedsInfoReplyDto,
+  toStudentApplicationSummaryDto,
 } from './application.mappers';
 import { APPLICATIONS_MESSAGES } from './applications.messages';
 import { UpdateApplicationGrantBudgetDto } from './dto/update-application-grant-budget.dto';
+import { StudentApplicationSummaryDto } from './dto/student-application-summary.dto';
 
 type RequiredDocumentSlot = {
   documentType: DocumentType;
@@ -108,6 +110,36 @@ export class ApplicationsService {
 
     return applications.map((application) =>
       toInternalProgramAApplicationDto(application),
+    );
+  }
+
+  async listSubmittedForCurrentTeam(
+    user: AuthenticatedUserContext,
+  ): Promise<StudentApplicationSummaryDto[]> {
+    const teams = await this.teamRepository.findActiveByUserId(user.id);
+
+    if (teams.length === 0) {
+      return [];
+    }
+
+    if (teams.length > 1) {
+      throw new ConflictException(
+        'Multiple active teams found for current user',
+      );
+    }
+
+    const [team] = teams;
+
+    if (!team) {
+      return [];
+    }
+
+    const applications = await this.applicationsRepository.listSubmittedForTeam(
+      team.id,
+    );
+
+    return applications.map((application) =>
+      toStudentApplicationSummaryDto(application),
     );
   }
 

--- a/src/applications/dto/student-application-summary.dto.ts
+++ b/src/applications/dto/student-application-summary.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ApplicationStatus,
+  CallStatus,
+  ProgramType,
+} from '../../../generated/prisma/enums';
+
+export class StudentApplicationCallSummaryDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiProperty({ enum: ProgramType })
+  type!: ProgramType;
+
+  @ApiProperty({ enum: CallStatus })
+  status!: CallStatus;
+}
+
+export class StudentApplicationSummaryDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  callId!: string;
+
+  @ApiProperty()
+  teamId!: string;
+
+  @ApiProperty({ enum: ApplicationStatus })
+  status!: ApplicationStatus;
+
+  @ApiProperty({ required: false, nullable: true })
+  submittedAt!: Date | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+
+  @ApiProperty({ type: StudentApplicationCallSummaryDto })
+  call!: StudentApplicationCallSummaryDto;
+}


### PR DESCRIPTION
## Summary

* Added a new endpoint for listing submitted applications for the current student team.
* Added `StudentApplicationSummaryDto` for dashboard-friendly application data.
* Included application status, submitted/updated dates, team id, call id, and call summary.
* Added repository, service, controller, mapper, and OpenAPI documentation updates.

## Testing

* `npm run typescript`
* `npm run test`
* `npm run build`
* Verified in Swagger: `GET /api/v1/applications/team/current/submitted`
* Verified with dev seed student accounts:

  * `student06@dev.local` shows a `NEEDS_INFO` application.
  * `student09@dev.local` shows a `SUBMITTED` application.

Related to YDVPWebDevTeam/NTI_frontend#37
