### PR TITLE
fix(program-b): allow assigned mentors to manage milestones

### DIFF
--- a/src/programs/program-b/projects/program-b-projects.controller.ts
+++ b/src/programs/program-b/projects/program-b-projects.controller.ts
@@ -106,7 +106,7 @@ export class ProgramBProjectsController {
   }
 
   @Post(':id/milestones')
-  @Roles(UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE)
+  @Roles(UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE, UserRole.MENTOR)
   createMilestone(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: CreateProgramBMilestoneDto,
@@ -116,7 +116,7 @@ export class ProgramBProjectsController {
   }
 
   @Patch(':id/milestones/:milestoneId')
-  @Roles(UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE)
+  @Roles(UserRole.COMPANY_OWNER, UserRole.COMPANY_EMPLOYEE, UserRole.MENTOR)
   updateMilestone(
     @Param('id', ParseUUIDPipe) id: string,
     @Param('milestoneId', ParseUUIDPipe) milestoneId: string,

--- a/src/programs/program-b/projects/program-b-projects.messages.ts
+++ b/src/programs/program-b/projects/program-b-projects.messages.ts
@@ -4,24 +4,38 @@ export const PROGRAM_B_PROJECTS_MESSAGES = {
   MILESTONE_NOT_FOUND: 'Milestone not found',
   MENTOR_USER_NOT_FOUND: 'Mentor user not found',
   TARGET_USER_MUST_BE_ACTIVE_MENTOR: 'Target user must be an active mentor',
+
   DOCUMENT_NOT_AVAILABLE_FOR_READING:
     'Document is not available for reading yet',
+
   CLOSED_PROJECTS_ARE_READ_ONLY: 'Closed Program B projects are read-only',
+
   REQUEST_BODY_EMPTY: 'Request body is empty',
+
   ONLY_COMPANY_MEMBERS_MAY_MANAGE_MILESTONES:
     'Only company-side project members may manage milestones',
+
+  ONLY_COMPANY_MEMBERS_OR_ASSIGNED_MENTORS_MAY_MANAGE_MILESTONES:
+    'Only company-side project members or the assigned mentor may manage milestones',
+
   ONLY_REVIEWERS_AND_MENTORS_MAY_CREATE_NOTES:
     'Only NTI-side reviewers and mentors may create mentoring notes',
+
   ONLY_REVIEWERS_AND_ASSIGNED_MENTORS_MAY_CREATE_NOTES:
     'Only NTI-side reviewers and assigned mentors may create mentoring notes',
+
   ONLY_ACTIVE_PO_MAY_CREATE_PO_REVIEWS:
     'Only the active assigned product owner may create PO reviews',
+
   ONLY_REVIEWERS_MAY_ASSIGN_MENTOR:
     'Only NTI-side reviewers may assign a mentor',
+
   ONLY_PO_OR_COMPANY_OWNER_MAY_RECORD_ACCEPTANCE:
     'Only the product owner or same-organization company owner may record company acceptance',
+
   ONLY_REVIEWERS_MAY_RECORD_NTI_ACCEPTANCE:
     'Only NTI-side reviewers may record NTI acceptance',
+
   DOCUMENT_VERSION_CONFLICT:
     'Could not assign a unique document version for this category',
 } as const;

--- a/src/programs/program-b/projects/program-b-projects.service.spec.ts
+++ b/src/programs/program-b/projects/program-b-projects.service.spec.ts
@@ -167,6 +167,27 @@ describe('ProgramBProjectsService', () => {
     organizationId: null,
   } as const;
 
+  const assignedMentor = {
+    id: 'mentor-1',
+    email: 'mentor@example.com',
+    role: UserRole.MENTOR,
+    status: UserStatus.ACTIVE,
+    organizationId: null,
+  } as const;
+
+  const unassignedMentor = {
+    id: 'mentor-2',
+    email: 'mentor-2@example.com',
+    role: UserRole.MENTOR,
+    status: UserStatus.ACTIVE,
+    organizationId: null,
+  } as const;
+
+  const inactiveAssignedMentor = {
+    ...assignedMentor,
+    status: UserStatus.PENDING,
+  } as const;
+
   const activeProject = {
     id: 'project-1',
     backlogItemId: 'backlog-1',
@@ -281,6 +302,65 @@ describe('ProgramBProjectsService', () => {
     );
 
     expect(result).toBe(milestone);
+  });
+
+  it('creates a milestone for the assigned mentor', async () => {
+    const milestone = {
+      id: 'milestone-1',
+      projectId: 'project-1',
+      title: 'Mentor checkpoint',
+      status: ProgramBMilestoneStatus.PLANNED,
+    };
+
+    projectsRepository.createMilestone.mockResolvedValue(milestone);
+
+    const result = await service.createMilestone(
+      'project-1',
+      {
+        title: 'Mentor checkpoint',
+        status: ProgramBMilestoneStatus.PLANNED,
+      },
+      assignedMentor as never,
+    );
+
+    expect(userRepository.findActiveOrganizationMember).not.toHaveBeenCalled();
+
+    expect(projectsRepository.createMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        title: 'Mentor checkpoint',
+        status: ProgramBMilestoneStatus.PLANNED,
+      }),
+      { tx: 'db-client' },
+    );
+
+    expect(result).toBe(milestone);
+  });
+
+  it('rejects an unassigned mentor from creating milestones', async () => {
+    await expect(
+      service.createMilestone(
+        'project-1',
+        { title: 'Unauthorized checkpoint' },
+        unassignedMentor as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(userRepository.findActiveOrganizationMember).not.toHaveBeenCalled();
+    expect(projectsRepository.createMilestone).not.toHaveBeenCalled();
+  });
+
+  it('rejects an inactive assigned mentor from creating milestones', async () => {
+    await expect(
+      service.createMilestone(
+        'project-1',
+        { title: 'Inactive mentor checkpoint' },
+        inactiveAssignedMentor as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(userRepository.findActiveOrganizationMember).not.toHaveBeenCalled();
+    expect(projectsRepository.createMilestone).not.toHaveBeenCalled();
   });
 
   it('allows company owners to manage milestones without team membership check', async () => {
@@ -513,6 +593,57 @@ describe('ProgramBProjectsService', () => {
     expect(result.title).toBe('Updated');
   });
 
+  it('updates a milestone for the assigned mentor', async () => {
+    projectsRepository.updateMilestoneForProject.mockResolvedValue({
+      count: 1,
+    });
+
+    projectsRepository.findMilestoneForProject.mockResolvedValue({
+      id: 'milestone-1',
+      projectId: 'project-1',
+      title: 'Updated by mentor',
+      status: ProgramBMilestoneStatus.IN_PROGRESS,
+    });
+
+    const result = await service.updateMilestone(
+      'project-1',
+      'milestone-1',
+      {
+        title: 'Updated by mentor',
+        status: ProgramBMilestoneStatus.IN_PROGRESS,
+      },
+      assignedMentor as never,
+    );
+
+    expect(userRepository.findActiveOrganizationMember).not.toHaveBeenCalled();
+
+    expect(projectsRepository.updateMilestoneForProject).toHaveBeenCalledWith(
+      'project-1',
+      'milestone-1',
+      {
+        title: 'Updated by mentor',
+        status: ProgramBMilestoneStatus.IN_PROGRESS,
+      },
+      { tx: 'db-client' },
+    );
+
+    expect(result.title).toBe('Updated by mentor');
+  });
+
+  it('rejects an unassigned mentor from updating milestones', async () => {
+    await expect(
+      service.updateMilestone(
+        'project-1',
+        'milestone-1',
+        { title: 'Unauthorized update' },
+        unassignedMentor as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(userRepository.findActiveOrganizationMember).not.toHaveBeenCalled();
+    expect(projectsRepository.updateMilestoneForProject).not.toHaveBeenCalled();
+  });
+
   it('rejects empty milestone update body', async () => {
     await expect(
       service.updateMilestone(
@@ -539,13 +670,7 @@ describe('ProgramBProjectsService', () => {
     const result = await service.createMentoringNote(
       'project-1',
       { note: 'Review deployment plan' },
-      {
-        id: 'mentor-1',
-        email: 'mentor@example.com',
-        role: UserRole.MENTOR,
-        status: UserStatus.ACTIVE,
-        organizationId: null,
-      } as never,
+      assignedMentor as never,
     );
 
     expect(projectsRepository.createMentoringNote).toHaveBeenCalledWith(
@@ -593,13 +718,7 @@ describe('ProgramBProjectsService', () => {
       service.createMentoringNote(
         'project-1',
         { note: 'Review deployment plan' },
-        {
-          id: 'mentor-2',
-          email: 'mentor-2@example.com',
-          role: UserRole.MENTOR,
-          status: UserStatus.ACTIVE,
-          organizationId: null,
-        } as never,
+        unassignedMentor as never,
       ),
     ).rejects.toBeInstanceOf(ForbiddenException);
 
@@ -611,13 +730,7 @@ describe('ProgramBProjectsService', () => {
       service.createMentoringNote(
         'project-1',
         { note: 'Review deployment plan' },
-        {
-          id: 'mentor-1',
-          email: 'mentor@example.com',
-          role: UserRole.MENTOR,
-          status: UserStatus.PENDING,
-          organizationId: null,
-        } as never,
+        inactiveAssignedMentor as never,
       ),
     ).rejects.toBeInstanceOf(ForbiddenException);
 

--- a/src/programs/program-b/projects/program-b-projects.service.ts
+++ b/src/programs/program-b/projects/program-b-projects.service.ts
@@ -109,7 +109,7 @@ export class ProgramBProjectsService {
       const project = await this.loadProjectOrThrow(projectId, db);
 
       this.ensureProjectWritable(project);
-      await this.ensureCompanySideProjectMember(project, user, db);
+      await this.ensureMilestoneManagementAccess(project, user, db);
       await this.promoteBacklogToRealizationIfNeeded(project, db);
 
       return this.projectsRepository.createMilestone(
@@ -143,7 +143,7 @@ export class ProgramBProjectsService {
       const project = await this.loadProjectOrThrow(projectId, db);
 
       this.ensureProjectWritable(project);
-      await this.ensureCompanySideProjectMember(project, user, db);
+      await this.ensureMilestoneManagementAccess(project, user, db);
       await this.promoteBacklogToRealizationIfNeeded(project, db);
 
       const result = await this.projectsRepository.updateMilestoneForProject(
@@ -594,6 +594,41 @@ export class ProgramBProjectsService {
       throw new ConflictException(
         PROGRAM_B_PROJECTS_MESSAGES.CLOSED_PROJECTS_ARE_READ_ONLY,
       );
+    }
+  }
+
+  private async ensureMilestoneManagementAccess(
+    project: ProgramBProjectExecutionView,
+    user: AuthenticatedUserContext,
+    db?: PrismaDbClient,
+  ): Promise<void> {
+    const forbiddenMessage =
+      PROGRAM_B_PROJECTS_MESSAGES.ONLY_COMPANY_MEMBERS_OR_ASSIGNED_MENTORS_MAY_MANAGE_MILESTONES;
+
+    if (user.status !== UserStatus.ACTIVE) {
+      throw new ForbiddenException(forbiddenMessage);
+    }
+
+    const isAssignedMentor =
+      user.role === UserRole.MENTOR && project.mentorUserId === user.id;
+
+    if (isAssignedMentor) {
+      return;
+    }
+
+    if (!isSameOrgCompanyMember(user, project.backlogItem.organizationId)) {
+      throw new ForbiddenException(forbiddenMessage);
+    }
+
+    const organizationMember =
+      await this.userRepository.findActiveOrganizationMember(
+        project.backlogItem.organizationId,
+        user.id,
+        db,
+      );
+
+    if (!organizationMember) {
+      throw new ForbiddenException(forbiddenMessage);
     }
   }
 


### PR DESCRIPTION
## Summary

- allow the assigned active mentor to create Program B milestones
- allow the assigned active mentor to update Program B milestones
- preserve existing company-side milestone permissions
- reject inactive and unassigned mentors
- add service tests for mentor milestone permissions

## Testing

- 32 ProgramBProjectsService tests passed
- TypeScript check passed
- production build passed

## Related frontend issue

Supports YDVPWebDevTeam/NTI_frontend#39