### PR TITLE
feat(program-a): expose mentor assignment and student mentorship note…

### DIFF
--- a/src/applications/application-access.service.ts
+++ b/src/applications/application-access.service.ts
@@ -242,6 +242,27 @@ export class ApplicationAccessService {
     );
   }
 
+  ensureMentorshipReadAccess(
+    application: ApplicationWorkflowView,
+    user: AuthenticatedUserContext,
+  ): void {
+    if (isAdminRole(user.role)) {
+      return;
+    }
+
+    if (user.role === UserRole.MENTOR && application.mentorUserId === user.id) {
+      return;
+    }
+
+    if (isTeamMember(application.team, user.id)) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      APPLICATIONS_MESSAGES.ONLY_ADMIN_OR_MENTOR_CAN_ACCESS_NOTES,
+    );
+  }
+
   ensureArchivedApplicationIsReadOnlyForNonAdmin(
     application: ApplicationWorkflowView,
     user: AuthenticatedUserContext,

--- a/src/applications/application.mappers.ts
+++ b/src/applications/application.mappers.ts
@@ -37,6 +37,17 @@ export function toDetailDto(
     decisionById: application.decisionById,
     decisionRationale: application.decisionRationale,
     grantBudget: application.grantBudget,
+    mentorAssignment: {
+      mentorUserId: application.mentorUserId,
+      mentor: application.mentorUser
+        ? toMentorshipNoteAuthorDto(application.mentorUser)
+        : null,
+      assignedAt: application.mentorAssignedAt,
+      assignedById: application.mentorAssignedById,
+      assignedBy: application.mentorAssignedBy
+        ? toMentorshipNoteAuthorDto(application.mentorAssignedBy)
+        : null,
+    },
     createdAt: application.createdAt,
     updatedAt: application.updatedAt,
   };

--- a/src/applications/applications.repository.ts
+++ b/src/applications/applications.repository.ts
@@ -357,6 +357,22 @@ export class ApplicationsRepository extends BaseRepository<
           status: true,
         },
       },
+      mentorUser: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+      mentorAssignedBy: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
     } as const;
   }
 

--- a/src/applications/applications.service.spec.ts
+++ b/src/applications/applications.service.spec.ts
@@ -1457,6 +1457,43 @@ describe('ApplicationsService', () => {
     expect(result.map((note) => note.id)).toEqual(['note-1', 'note-2']);
   });
 
+  it('allows team member to list mentorship notes for their application', async () => {
+    applicationsRepository.findByIdForWorkflow.mockResolvedValue({
+      ...workflowApplication,
+      status: ApplicationStatus.ACTIVE_PROJECT,
+      mentorUserId: 'mentor-1',
+    });
+    programAMentorshipRepository.listNotes.mockResolvedValue([
+      {
+        id: 'note-1',
+        applicationId: 'application-1',
+        authorId: 'mentor-1',
+        content: 'Shared update',
+        createdAt: new Date('2026-05-13T08:00:00.000Z'),
+        author: {
+          id: 'mentor-1',
+          email: 'mentor@example.com',
+          firstName: 'Mina',
+          lastName: 'Tor',
+        },
+      },
+    ]);
+
+    const result = await mentorshipService.listMentorshipNotes(
+      'application-1',
+      {
+        id: 'user-2',
+        email: 'member@example.com',
+        role: UserRole.STUDENT,
+      } as never,
+    );
+
+    expect(programAMentorshipRepository.listNotes).toHaveBeenCalledWith(
+      'application-1',
+    );
+    expect(result.map((note) => note.id)).toEqual(['note-1']);
+  });
+
   describe('Program A milestones', () => {
     const approvedProgramAApplication = {
       ...workflowApplication,

--- a/src/applications/dto/application-detail.dto.ts
+++ b/src/applications/dto/application-detail.dto.ts
@@ -1,5 +1,23 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ApplicationStatus } from '../../../generated/prisma/enums';
+import { MentorshipNoteAuthorDto } from './mentorship-note-author.dto';
+
+export class ApplicationMentorAssignmentDto {
+  @ApiPropertyOptional({ format: 'uuid' })
+  mentorUserId?: string | null;
+
+  @ApiPropertyOptional({ type: MentorshipNoteAuthorDto })
+  mentor?: MentorshipNoteAuthorDto | null;
+
+  @ApiPropertyOptional()
+  assignedAt?: Date | null;
+
+  @ApiPropertyOptional({ format: 'uuid' })
+  assignedById?: string | null;
+
+  @ApiPropertyOptional({ type: MentorshipNoteAuthorDto })
+  assignedBy?: MentorshipNoteAuthorDto | null;
+}
 
 export class ApplicationDetailDto {
   @ApiProperty({ example: 'f6c90688-c973-40ca-8f3b-c55667cc6f77' })
@@ -31,6 +49,9 @@ export class ApplicationDetailDto {
 
   @ApiPropertyOptional({ nullable: true, example: 5000 })
   grantBudget!: number | null;
+
+  @ApiPropertyOptional({ type: ApplicationMentorAssignmentDto })
+  mentorAssignment?: ApplicationMentorAssignmentDto | null;
 
   @ApiProperty()
   createdAt!: Date;

--- a/src/programs/program-a/program-a-mentorship.service.ts
+++ b/src/programs/program-a/program-a-mentorship.service.ts
@@ -155,7 +155,7 @@ export class ProgramAMentorshipService {
 
     this.applicationAccess.ensureProgramAMentorshipWorkflow(application);
     this.applicationAccess.ensureMentorAssigned(application);
-    this.applicationAccess.ensureMentorshipAccess(application, user);
+    this.applicationAccess.ensureMentorshipReadAccess(application, user);
 
     const notes = await this.programAMentorshipRepository.listNotes(
       application.id,


### PR DESCRIPTION

## Summary:
- exposed mentor assignment data in Program A application detail responses so the student project view can show the assigned mentor
- allowed student team members to read mentorship notes for their own Program A application
- kept mentorship note creation restricted to the assigned mentor and admin-side users
- added backend test coverage for student access to Program A mentorship notes

## Preview:
- backend API:
  - `GET /api/v1/applications/:id`
  - `GET /api/v1/applications/:id/mentorship-notes`

## Issue ticket number and link:
- supports the frontend task for the Program A student post-approval project view
- depends  lifecycle transitions from the admin side

## Dependencies:
- depends on admin lifecycle transitions
- intended to be used together with the frontend Program A post-approval project view changes
