### PR TITLE
fix: update student confirmation path and regenerate Prisma client on…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,10 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends chromium fonts-liberation ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# --- Dependencies: full install, cached on package files only ---------------
 FROM base AS deps
 COPY package*.json ./
 RUN npm ci
 
-# --- Builder: generate Prisma client + compile TypeScript -------------------
 FROM deps AS builder
 COPY . .
 RUN npx prisma generate && npm run build
@@ -48,8 +46,6 @@ RUN npx prisma generate
 EXPOSE 3001
 CMD ["npm", "run", "start:dev"]
 
-# Holds everything both entrypoints need. The API (`production`) and the worker
-# only differ by CMD, so they both inherit from here.
 FROM chromium AS runtime
 ENV NODE_ENV=production
 COPY --from=prod-deps /app/node_modules ./node_modules
@@ -58,7 +54,6 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
 COPY --from=builder /app/generated ./generated
 COPY package*.json ./
-# Prisma CLI lives in dev deps, so pull it from the builder for `migrate deploy`.
 COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ x-app-base: &app-base
 services:
   app:
     <<: *app-base
-    command: sh -c "npx prisma migrate deploy && npm run start:dev"
+    # Regenerate the client on every boot so the anonymous /app/generated
+    # volume always matches the current schema; a stale client otherwise
+    # survives across rebuilds and breaks compilation on schema changes.
+    command: sh -c "npx prisma generate && npx prisma migrate deploy && npm run start:dev"
     ports:
       - '3001:3001'
     healthcheck:
@@ -49,7 +52,7 @@ services:
   worker:
     <<: *app-base
     profiles: ['worker']
-    command: npm run start:worker:dev
+    command: sh -c "npx prisma generate && npm run start:worker:dev"
 
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ x-app-base: &app-base
     TSC_WATCHFILE: UsePolling
   volumes:
     - .:/app
-    # Keep the image's node_modules / generated client instead of the host's.
     - /app/node_modules
     - /app/generated
   depends_on:
@@ -31,15 +30,17 @@ x-app-base: &app-base
 services:
   app:
     <<: *app-base
-    # Regenerate the client on every boot so the anonymous /app/generated
-    # volume always matches the current schema; a stale client otherwise
-    # survives across rebuilds and breaks compilation on schema changes.
     command: sh -c "npx prisma generate && npx prisma migrate deploy && npm run start:dev"
     ports:
       - '3001:3001'
     healthcheck:
       test:
-        ['CMD', 'node', '-e', "require('http').get('http://localhost:3001/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('http').get('http://localhost:3001/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))",
+        ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -721,7 +721,7 @@ describe('AuthService', () => {
       {
         email: unconfirmedUser.email,
         token: 'new-verification-token',
-        confirmationPath: '/register/student',
+        confirmationPath: '/verify-email',
       },
     );
   });

--- a/src/auth/confirmation-paths.ts
+++ b/src/auth/confirmation-paths.ts
@@ -1,7 +1,7 @@
 import { UserRole } from '../../generated/prisma/enums';
 
 export const CONFIRMATION_PATHS = {
-  STUDENT: '/register/student',
+  STUDENT: '/verify-email',
   COMPANY_OWNER: '/register/company-owner/confirm-email',
 } as const;
 

--- a/src/infrastructure/mailer/email-template-registry.service.spec.ts
+++ b/src/infrastructure/mailer/email-template-registry.service.spec.ts
@@ -22,17 +22,17 @@ describe('EmailTemplateRegistryService', () => {
   it('renders user confirmation with shared layout and text fallback', () => {
     const result = service.render(EMAIL_TEMPLATES.USER_CONFIRMATION, {
       token: 'confirm-token',
-      confirmationPath: '/register/student',
+      confirmationPath: '/verify-email',
     });
 
     expect(result.subject).toBe('Email confirmation');
     expect(result.html).toContain('Confirm your email');
     expect(result.html).toContain(
-      'https://app.nti.test/register/student?token=confirm-token',
+      'https://app.nti.test/verify-email?token=confirm-token',
     );
     expect(result.html).toContain('NTI automated email');
     expect(result.text).toContain(
-      'Confirm email: https://app.nti.test/register/student?token=confirm-token',
+      'Confirm email: https://app.nti.test/verify-email?token=confirm-token',
     );
   });
 

--- a/src/infrastructure/queue/processors/email.processor.spec.ts
+++ b/src/infrastructure/queue/processors/email.processor.spec.ts
@@ -76,7 +76,7 @@ describe('EmailProcessor', () => {
       data: {
         email: 'student@example.com',
         token: 'confirm-token',
-        confirmationPath: '/register/student',
+        confirmationPath: '/verify-email',
       },
     } as Job<
       {
@@ -93,7 +93,7 @@ describe('EmailProcessor', () => {
     expect(mailerService.sendConfirmationEmail).toHaveBeenCalledWith(
       'student@example.com',
       'confirm-token',
-      '/register/student',
+      '/verify-email',
     );
   });
 


### PR DESCRIPTION
… boot

Change the student email confirmation path to /verify-email and run prisma generate on container startup so the generated client stays in sync with the schema across rebuilds.